### PR TITLE
feat: prepare agentctl v0.3.0 for public release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Charlie Hulcher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,214 @@
+# agentctl
+
+Universal agent supervision interface. Monitor and control AI coding agents from a single CLI.
+
+agentctl reads from native sources (Claude Code's `~/.claude/` directory, running processes) and provides a standard interface to list, inspect, stop, launch, and resume agent sessions. It never replicates state — it reads what's actually happening.
+
+## Layer Model
+
+| Layer | Role |
+|-------|------|
+| **agentctl** | Read/control interface. Discovers sessions, emits lifecycle events. |
+| **OrgLoop** | Routes lifecycle events to mechanical reactions (cluster fuse, notifications). |
+| **OpenClaw** | Reasoning layer. Makes judgment calls about what to do. |
+
+agentctl intentionally does **not**:
+- Maintain its own session registry (reads native sources)
+- Have a hook/reaction system (that's OrgLoop)
+- Make judgment calls about what to do (that's OpenClaw)
+
+## Installation
+
+```bash
+npm install -g agentctl
+```
+
+Requires Node.js >= 20.
+
+## Quick Start
+
+```bash
+# List running sessions
+agentctl list
+
+# List all sessions (including stopped, last 7 days)
+agentctl list -a
+
+# Peek at recent output from a session
+agentctl peek <session-id>
+
+# Launch a new Claude Code session
+agentctl launch -p "Read the spec and implement phase 2"
+
+# Stop a session
+agentctl stop <session-id>
+
+# Resume a stopped session with a new message
+agentctl resume <session-id> "fix the failing tests"
+```
+
+Session IDs support prefix matching — `agentctl peek abc123` matches any session starting with `abc123`.
+
+## CLI Reference
+
+### Session Management
+
+```bash
+agentctl list [options]
+  --adapter <name>     Filter by adapter (claude-code, openclaw)
+  --status <status>    Filter by status (running|stopped|idle|error)
+  -a, --all            Include stopped sessions (last 7 days)
+  --json               Output as JSON
+
+agentctl status <id> [options]
+  --adapter <name>     Adapter to use
+  --json               Output as JSON
+
+agentctl peek <id> [options]
+  -n, --lines <n>      Number of recent messages (default: 20)
+  --adapter <name>     Adapter to use
+
+agentctl launch [adapter] [options]
+  -p, --prompt <text>  Prompt to send (required)
+  --spec <path>        Spec file path
+  --cwd <dir>          Working directory
+  --model <model>      Model to use (e.g. sonnet, opus)
+  --force              Override directory locks
+
+agentctl stop <id> [options]
+  --force              Force kill (SIGINT then SIGKILL)
+  --adapter <name>     Adapter to use
+
+agentctl resume <id> <message> [options]
+  --adapter <name>     Adapter to use
+
+agentctl events [options]
+  --json               Output as NDJSON (default)
+```
+
+### Directory Locks
+
+agentctl tracks which directories have active sessions to prevent conflicting launches.
+
+```bash
+agentctl lock <directory> [options]
+  --by <name>          Who is locking
+  --reason <reason>    Why
+
+agentctl unlock <directory>
+
+agentctl locks [options]
+  --json               Output as JSON
+```
+
+### Fuse Timers
+
+For Kind cluster management — automatically shuts down clusters when sessions end.
+
+```bash
+agentctl fuses [options]
+  --json               Output as JSON
+```
+
+### Daemon
+
+The daemon provides session tracking, directory locks, fuse timers, and Prometheus metrics. It auto-starts on first `agentctl` command.
+
+```bash
+agentctl daemon start [options]
+  --foreground         Run in foreground (don't daemonize)
+  --metrics-port       Prometheus metrics port (default: 9200)
+
+agentctl daemon stop
+agentctl daemon status
+agentctl daemon restart
+
+agentctl daemon install    # Install macOS LaunchAgent (auto-start on login)
+agentctl daemon uninstall  # Remove LaunchAgent
+```
+
+Metrics are exposed at `http://localhost:9200/metrics` in Prometheus text format.
+
+## Adapters
+
+agentctl uses an adapter architecture to support different agent runtimes.
+
+### Claude Code (default)
+
+Reads session data from `~/.claude/projects/` and cross-references with running `claude` processes. Detects PID recycling via process start time verification. Tracks detached processes that survive wrapper exit.
+
+### OpenClaw
+
+Connects to the OpenClaw gateway via WebSocket RPC. Read-only — sessions are managed through the gateway.
+
+### Writing an Adapter
+
+Implement the `AgentAdapter` interface:
+
+```typescript
+interface AgentAdapter {
+  id: string;
+  list(opts?: ListOpts): Promise<AgentSession[]>;
+  peek(sessionId: string, opts?: PeekOpts): Promise<string>;
+  status(sessionId: string): Promise<AgentSession>;
+  launch(opts: LaunchOpts): Promise<AgentSession>;
+  stop(sessionId: string, opts?: StopOpts): Promise<void>;
+  resume(sessionId: string, message: string): Promise<void>;
+  events(): AsyncIterable<LifecycleEvent>;
+}
+```
+
+## Configuration
+
+agentctl stores daemon state in `~/.agentctl/`:
+
+```
+~/.agentctl/
+  agentctl.sock          # Unix socket for CLI ↔ daemon communication
+  agentctl.pid           # Daemon PID file
+  state.json             # Session tracking state
+  locks.json             # Directory locks
+  fuses.json             # Fuse timers
+  daemon.stdout.log      # Daemon stdout
+  daemon.stderr.log      # Daemon stderr
+```
+
+## Development
+
+```bash
+git clone https://github.com/c-h-/agentctl.git
+cd agentctl
+npm install
+npm run build
+npm link              # makes agentctl available globally
+```
+
+```bash
+npm run dev           # run CLI via tsx (no build needed)
+npm test              # vitest
+npm run typecheck     # tsc --noEmit
+npm run lint          # biome check
+```
+
+### Project Structure
+
+```
+src/
+  cli.ts                         # CLI entry point (commander)
+  core/types.ts                  # Core interfaces
+  adapters/claude-code.ts        # Claude Code adapter
+  adapters/openclaw.ts           # OpenClaw gateway adapter
+  daemon/server.ts               # Daemon: Unix socket server + HTTP metrics
+  daemon/session-tracker.ts      # Session lifecycle tracking
+  daemon/lock-manager.ts         # Directory locks
+  daemon/fuse-engine.ts          # Kind cluster fuse timers
+  daemon/metrics.ts              # Prometheus metrics registry
+  daemon/state.ts                # State persistence
+  daemon/launchagent.ts          # macOS LaunchAgent plist generator
+  client/daemon-client.ts        # Unix socket client
+  migration/migrate-locks.ts     # Migration from legacy locks
+```
+
+## License
+
+MIT

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,17 +1,17 @@
-# agent-ctl v2 — Universal Agent Supervision Interface
+# agentctl — Universal Agent Supervision Interface
 
-**Status:** 🟢 Phase 1 Complete
+**Status:** 🟢 Phase 1 Complete, v0.3.0 preparing for public release
 **Author:** Charlie Hulcher + Jarvis
 **Date:** 2026-02-16
-**Repos:** `~/personal/agent-ctl` (new), `~/personal/orgloop`, `~/personal/arc`
+**Repos:** `~/personal/agentctl-publish`, `~/personal/orgloop`, `~/personal/arc`
 
 ---
 
 ## Vision
 
-agent-ctl is a universal read/control interface for AI agent sessions. It reads from native sources (never replicates state), provides a standard CLI for humans and agents to list/peek/stop/launch sessions, and emits lifecycle events that OrgLoop routes to mechanical reactions.
+agentctl is a universal read/control interface for AI agent sessions. It reads from native sources (never replicates state), provides a standard CLI for humans and agents to list/peek/stop/launch sessions, and emits lifecycle events that OrgLoop routes to mechanical reactions.
 
-**agent-ctl does NOT:**
+**agentctl does NOT:**
 - Maintain its own session registry (reads native sources)
 - Have a hook/reaction system (that's OrgLoop)
 - Make judgment calls about what to do (that's OpenClaw)
@@ -19,21 +19,21 @@ agent-ctl is a universal read/control interface for AI agent sessions. It reads 
 **Layer model:**
 | Layer | Role |
 |-------|------|
-| agent-ctl | Universal read/control. Emits lifecycle events. |
+| agentctl | Universal read/control. Emits lifecycle events. |
 | OrgLoop | Routes lifecycle events to mechanical reactions (cluster fuse, notifications). |
 | OpenClaw | Reasoning/supervision. Makes judgment calls. |
 
 ---
 
-## Phase 1: agent-ctl Core + Claude Code Adapter
+## Phase 1: agentctl Core + Claude Code Adapter
 
 ### 1.1 Repo Setup
 
-- Create `~/personal/agent-ctl/` as TypeScript project
-- GitHub: `gh-me repo create agent-ctl --private`
+- TypeScript project, ESM-only
+- GitHub: `c-h-/agentctl` (was `agent-ctl`, renamed)
 - Runtime: Node.js + TypeScript (Bun-compatible)
-- Package name: `agent-ctl` (for eventual npm publish)
-- Binary: `agent-ctl` via package.json `bin`
+- Package name: `agentctl` (npm)
+- Binary: `agentctl` (primary), `agent-ctl` (compat alias)
 
 ### 1.2 Adapter Interface
 
@@ -137,40 +137,40 @@ interface LaunchOpts {
 
 ```bash
 # List all sessions across all adapters
-agent-ctl list
-agent-ctl list --adapter claude-code
-agent-ctl list --status running
-agent-ctl list -a  # Include stopped/completed (last 7 days)
+agentctl list
+agentctl list --adapter claude-code
+agentctl list --status running
+agentctl list -a  # Include stopped/completed (last 7 days)
 
 # Session details
-agent-ctl status <id>
-agent-ctl peek <id> [-n 50]
+agentctl status <id>
+agentctl peek <id> [-n 50]
 
 # Control
-agent-ctl stop <id>
-agent-ctl stop <id> --force
-agent-ctl resume <id> "fix the failing tests"
+agentctl stop <id>
+agentctl stop <id> --force
+agentctl resume <id> "fix the failing tests"
 
 # Launch (replaces claude-supervised)
-agent-ctl launch claude-code \
+agentctl launch claude-code \
   -p "Read the spec. Implement phase 2." \
   --spec docs/spec.md \
   --cwd ~/personal/my-project \
   --model sonnet
 
 # Event stream (for debugging / piping to OrgLoop)
-agent-ctl events --json
+agentctl events --json
 ```
 
 **Output format:** Human-friendly table by default, `--json` for machine consumption.
 
 ### 1.5 Acceptance Criteria — Phase 1
 
-- [x] `agent-ctl list` shows only real, live Claude Code sessions (no stale ghosts)
-- [x] `agent-ctl peek <id>` shows recent output from a running session
-- [x] `agent-ctl stop <id>` gracefully stops a running session
-- [x] `agent-ctl launch claude-code -p "hello"` starts a session (replaces claude-supervised)
-- [x] `agent-ctl events --json` emits lifecycle events as NDJSON
+- [x] `agentctl list` shows only real, live Claude Code sessions (no stale ghosts)
+- [x] `agentctl peek <id>` shows recent output from a running session
+- [x] `agentctl stop <id>` gracefully stops a running session
+- [x] `agentctl launch claude-code -p "hello"` starts a session (replaces claude-supervised)
+- [x] `agentctl events --json` emits lifecycle events as NDJSON
 - [x] Zero file-based registry — all state from native sources
 - [x] Tests: unit tests for adapter (14 tests passing)
 - [ ] Integration test launching+stopping a real session (deferred to Phase 2)
@@ -180,20 +180,20 @@ agent-ctl events --json
 ## Phase 2: Cut Over
 
 ### 2.1 Update Dependents
-- Update `~/.openclaw/workspaces/personal/TOOLS.md` — document new `agent-ctl launch` syntax
+- Update `~/.openclaw/workspaces/personal/TOOLS.md` — document new `agentctl launch` syntax
 - Update `~/.openclaw/workspaces/personal/CLAUDE_CODE_SOP.md` — replace `claude-supervised` references
-- Update `~/personal/arc/daemon/src/adapters/` — swap to new agent-ctl interface
-- Symlink or install `agent-ctl` binary globally (`npm link` or PATH addition)
+- Update `~/personal/arc/daemon/src/adapters/` — swap to new agentctl interface
+- Symlink or install `agentctl` binary globally (`npm link` or PATH addition)
 
 ### 2.2 Delete Old Artifacts
-- `~/.openclaw/scripts/agent-ctl/` (old implementation)
-- `~/.local/bin/claude-supervised` (absorbed into agent-ctl)
-- `~/.openclaw/scripts/agent-ctl/sessions/` (stale file registry)
+- `~/.openclaw/scripts/agentctl/` (old implementation)
+- `~/.local/bin/claude-supervised` (absorbed into agentctl)
+- `~/.openclaw/scripts/agentctl/sessions/` (stale file registry)
 - `~/.local/bin/notify-doink.sh` or wherever the stop hook lives
 - Any Claude Code Stop hook that calls notify-doink
 
 ### 2.3 Acceptance Criteria — Phase 2
-- [ ] `claude-supervised` no longer exists; `agent-ctl launch` is the only way
+- [ ] `claude-supervised` no longer exists; `agentctl launch` is the only way
 - [ ] ARC dashboard shows live, accurate session data
 - [ ] OpenClaw workspace docs reference new commands
 - [ ] No stale session files anywhere on disk
@@ -202,18 +202,18 @@ agent-ctl events --json
 
 ## Phase 3: OrgLoop Connectors
 
-### 3.1 `@orgloop/connector-agent-ctl` (Source)
+### 3.1 `@orgloop/connector-agentctl` (Source)
 
-Reads lifecycle events from agent-ctl and emits them as OrgLoop events.
+Reads lifecycle events from agentctl and emits them as OrgLoop events.
 
 ```typescript
-// connector-agent-ctl/src/index.ts
+// connector-agentctl/src/index.ts
 export default class AgentCtlConnector implements SourceConnector {
-  // Runs `agent-ctl events --json` and pipes lifecycle events into OrgLoop
-  // Or: polls `agent-ctl list --json` on interval (simpler, good enough)
+  // Runs `agentctl events --json` and pipes lifecycle events into OrgLoop
+  // Or: polls `agentctl list --json` on interval (simpler, good enough)
   
   async poll(): Promise<OrgLoopEvent[]> {
-    const sessions = await exec('agent-ctl list --json');
+    const sessions = await exec('agentctl list --json');
     // Diff against last poll, emit started/stopped events
   }
 }
@@ -252,7 +252,7 @@ export default class DockerConnector implements ActorConnector {
 # In orgloop.yaml
 sources:
   - id: agents
-    connector: "@orgloop/connector-agent-ctl"
+    connector: "@orgloop/connector-agentctl"
     poll: { interval: 30s }
 
 actors:
@@ -293,7 +293,7 @@ routes:
 ```
 
 ### 3.5 Acceptance Criteria — Phase 3
-- [ ] `@orgloop/connector-agent-ctl` published and working in OrgLoop pipeline
+- [ ] `@orgloop/connector-agentctl` published and working in OrgLoop pipeline
 - [ ] `@orgloop/connector-docker` published and working
 - [ ] Kind cluster fuse works via OrgLoop route (replaces bespoke bash script)
 - [ ] Session completion notifications flow through OrgLoop → OpenClaw
@@ -314,25 +314,25 @@ routes:
 - Gas Town actors (once OrgLoop actors have session-like lifecycle)
 
 ### 4.3 ARC Simplification
-- ARC's multiple adapters (agent-ctl, openclaw, github, git, system) consolidate
-- agent-ctl becomes the single source for all agent data
+- ARC's multiple adapters (agentctl, openclaw, github, git, system) consolidate
+- agentctl becomes the single source for all agent data
 - ARC keeps system/github/git adapters (those aren't agents)
 
 ---
 
 ## Build Plan — Claude Code Teams
 
-### Team 1: agent-ctl core + Claude Code adapter
-- **Repo:** `~/personal/agent-ctl`
+### Team 1: agentctl core + Claude Code adapter
+- **Repo:** `~/personal/agentctl`
 - **Scope:** Phase 1 entirely — scaffold, adapter interface, Claude Code adapter, CLI, tests
 - **Isolation:** Can build and test completely standalone
 - **Depends on:** Nothing
 
-### Team 2: OrgLoop connector-agent-ctl
+### Team 2: OrgLoop connector-agentctl
 - **Repo:** `~/personal/orgloop` (new package in monorepo)
-- **Scope:** Phase 3.1 — source connector that reads from agent-ctl
-- **Isolation:** Can build with mock agent-ctl output, test against real agent-ctl once Team 1 ships
-- **Depends on:** agent-ctl CLI interface (Team 1 must define JSON output format first)
+- **Scope:** Phase 3.1 — source connector that reads from agentctl
+- **Isolation:** Can build with mock agentctl output, test against real agentctl once Team 1 ships
+- **Depends on:** agentctl CLI interface (Team 1 must define JSON output format first)
 
 ### Team 3: OrgLoop connector-docker
 - **Repo:** `~/personal/orgloop` (new package in monorepo)
@@ -341,7 +341,7 @@ routes:
 - **Depends on:** Nothing (OrgLoop actor interface already defined)
 
 ### Integration (after all teams complete):
-- Wire agent-ctl into ARC (Phase 4.3)
+- Wire agentctl into ARC (Phase 4.3)
 - Cut over from old scripts (Phase 2)
 - Wire OrgLoop routes for cluster fuse + notifications (Phase 3.3-3.4)
 - **This is done manually/supervised, not by Claude Code teams**
@@ -352,9 +352,9 @@ routes:
 
 | Question | Decision |
 |----------|----------|
-| Where does supervision loop live? | OpenClaw. agent-ctl is mechanical only. |
-| Hook execution model? | No hooks in agent-ctl. OrgLoop handles reactions. |
-| agent-ctl repo location? | Own private repo, pathway to open source npm. |
+| Where does supervision loop live? | OpenClaw. agentctl is mechanical only. |
+| Hook execution model? | No hooks in agentctl. OrgLoop handles reactions. |
+| agentctl repo location? | Own private repo, pathway to open source npm. |
 | Kind cluster fuse? | OrgLoop route via connector-docker, not bespoke script. |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "agent-ctl",
-  "version": "0.1.0",
+  "name": "agentctl",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-ctl",
-      "version": "0.1.0",
+      "name": "agentctl",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",
@@ -16,10 +16,14 @@
         "vitest": "^4.0.18"
       },
       "bin": {
-        "agent-ctl": "dist/cli.js"
+        "agent-ctl": "dist/compat-shim.js",
+        "agentctl": "dist/cli.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "agentctl",
-  "version": "0.2.0-alpha.1",
-  "description": "Universal agent supervision interface",
+  "version": "0.3.0",
+  "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {
     "agentctl": "./dist/cli.js",
     "agent-ctl": "./dist/compat-shim.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts",
@@ -18,9 +23,27 @@
     "format": "biome format --write src/",
     "prepare": "git config core.hooksPath .githooks"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/c-h-/agentctl.git"
+  },
+  "homepage": "https://github.com/c-h-/agentctl#readme",
+  "bugs": {
+    "url": "https://github.com/c-h-/agentctl/issues"
+  },
+  "keywords": [
+    "cli",
+    "agent",
+    "ai",
+    "supervisor",
+    "claude",
+    "coding-agent"
+  ],
   "author": "Charlie Hulcher <charlie.hulcher@gmail.com>",
   "license": "MIT",
-  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@types/node": "^25.2.3",
     "commander": "^14.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "declaration": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- **Rename to agentctl** throughout: package.json, SPEC.md, CLI version string. `agent-ctl` kept as compat binary alias.
- **Session lifecycle bugs (BUG-1/2/3/4/5)**: Already fixed in prior PRs — process start time tracking, PID recycling detection, detached process support. 106 tests cover all cases.
- **Daemon supervisor**: Auto-start daemon on first `agentctl` command, `daemon restart` command, LaunchAgent plist for macOS auto-start on login.
- **README.md**: Comprehensive public-facing documentation — installation, CLI reference, adapter architecture, configuration, development setup.
- **npm publish prep**: Remove `private: true`, bump to v0.3.0, add `files` field (dist + README + LICENSE only), add `repository`/`homepage`/`bugs`/`engines`/`keywords`, MIT LICENSE file, exclude test files from build output.

## Changes

| File | Change |
|------|--------|
| `package.json` | v0.3.0, remove private, add npm metadata, files field |
| `tsconfig.json` | Exclude test files from build output |
| `src/cli.ts` | Auto-start daemon (`ensureDaemon()`), `daemon restart` command, version bump |
| `SPEC.md` | Rename agent-ctl → agentctl throughout |
| `README.md` | New — full CLI reference, architecture, development setup |
| `LICENSE` | New — MIT |
| `package-lock.json` | Updated for version bump |

## Test plan

- [x] `npm test` — 106 tests passing (10 test files)
- [x] `npm run typecheck` — clean
- [x] `npx biome check src/` — clean
- [x] `npm run build` — clean
- [x] `npm pack --dry-run` — 31 files, no test files in tarball, 28KB packed

🤖 Generated with [Claude Code](https://claude.com/claude-code)