### PR TITLE
release: v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentctl",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentctl",
-      "version": "0.3.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
First public release of `@orgloop/agentctl`.

- Package: `@orgloop/agentctl`
- Version: 1.0.0
- 131 tests passing
- Publish workflow will trigger on `v1.0.0` tag after merge