### PR TITLE
fix: match GitHub org casing for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/orgloop/agentctl.git"
+    "url": "git+https://github.com/OrgLoop/agentctl.git"
   },
   "homepage": "https://github.com/c-h-/agentctl#readme",
   "bugs": {


### PR DESCRIPTION
npm provenance validation requires exact case match. GitHub org is `OrgLoop` not `orgloop`.