### PR TITLE
fix: reap ghost sessions and deduplicate pending entries

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -259,7 +259,8 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       resolvedSessionId = await this.pollForSessionId(logPath, pid, 5000);
     }
 
-    const sessionId = resolvedSessionId || crypto.randomUUID();
+    const sessionId =
+      resolvedSessionId || (pid ? `pending-${pid}` : crypto.randomUUID());
 
     // Persist session metadata so status checks work after wrapper exits
     if (pid) {


### PR DESCRIPTION
Fixes ghost session cleanup and deduplicates pending-* state entries in agentctl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)