### PR TITLE
feat(openclaw): add Ed25519 device auth for scoped gateway access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agentctl",
+  "name": "@orgloop/agentctl",
   "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentctl",
+      "name": "@orgloop/agentctl",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
@@ -969,7 +969,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1267,7 +1266,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1428,7 +1426,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1467,7 +1464,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
The gateway strips all scopes for token-only auth (no device block). This means sessions.list and other operator.read methods fail with "missing scope: operator.read" even with a valid token.

Implement the same device auth flow as the OpenClaw CLI:
- Generate/load Ed25519 key pair at ~/.agentctl/identity/device.json
- Sign the connect payload (v2 with nonce from challenge)
- Include device block (id, publicKey, signature, signedAt, nonce)

The gateway auto-trusts devices that also provide a valid shared token, so no manual pairing step is needed.

Tested: agentctl now sees all OpenClaw sessions (running, idle, stopped) including thread sessions, sub-agents, and channel sessions.

149 tests (15 new), lint + typecheck clean.