### PR TITLE
fix: reduce daemon CPU saturation from full JSONL reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1266,6 +1267,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1426,6 +1428,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1464,6 +1467,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/utils/partial-read.test.ts
+++ b/src/utils/partial-read.test.ts
@@ -1,0 +1,192 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readHead, readTail } from "./partial-read.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "partial-read-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function filePath(name: string): string {
+  return path.join(tmpDir, name);
+}
+
+describe("readHead", () => {
+  it("reads first N lines from a small file", async () => {
+    const fp = filePath("small.jsonl");
+    await fs.writeFile(fp, "line1\nline2\nline3\nline4\nline5\n");
+
+    const lines = await readHead(fp, 3);
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
+  it("returns all lines when file has fewer than maxLines", async () => {
+    const fp = filePath("short.jsonl");
+    await fs.writeFile(fp, "a\nb\n");
+
+    const lines = await readHead(fp, 10);
+    expect(lines).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array for empty file", async () => {
+    const fp = filePath("empty.jsonl");
+    await fs.writeFile(fp, "");
+
+    const lines = await readHead(fp, 5);
+    expect(lines).toEqual([]);
+  });
+
+  it("handles file with no trailing newline", async () => {
+    const fp = filePath("notail.jsonl");
+    await fs.writeFile(fp, "only-line");
+
+    const lines = await readHead(fp, 5);
+    expect(lines).toEqual(["only-line"]);
+  });
+
+  it("truncates at maxBytes and drops partial last line", async () => {
+    const fp = filePath("large.jsonl");
+    // Each line is 10 chars + newline = 11 bytes
+    const content = `${Array.from(
+      { length: 100 },
+      (_, i) => `line-${String(i).padStart(4, "0")}`,
+    ).join("\n")}\n`;
+    await fs.writeFile(fp, content);
+
+    // Read only 55 bytes — should get 5 complete lines (each ~10 chars + newline)
+    const lines = await readHead(fp, 100, 55);
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines[0]).toBe("line-0000");
+    // All returned lines should be complete
+    for (const l of lines) {
+      expect(l).toMatch(/^line-\d{4}$/);
+    }
+  });
+
+  it("works with JSON lines", async () => {
+    const fp = filePath("json.jsonl");
+    const jsonLines = [
+      JSON.stringify({
+        type: "user",
+        cwd: "/test",
+        message: { content: "hello" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: { model: "claude-opus-4-6" },
+      }),
+      JSON.stringify({ type: "user", message: { content: "world" } }),
+    ];
+    await fs.writeFile(fp, `${jsonLines.join("\n")}\n`);
+
+    const lines = await readHead(fp, 2, 8192);
+    expect(lines).toHaveLength(2);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.cwd).toBe("/test");
+  });
+});
+
+describe("readTail", () => {
+  it("reads last N lines from a small file", async () => {
+    const fp = filePath("small-tail.jsonl");
+    await fs.writeFile(fp, "line1\nline2\nline3\nline4\nline5\n");
+
+    const lines = await readTail(fp, 3);
+    expect(lines).toEqual(["line3", "line4", "line5"]);
+  });
+
+  it("returns all lines when file has fewer than maxLines", async () => {
+    const fp = filePath("short-tail.jsonl");
+    await fs.writeFile(fp, "a\nb\n");
+
+    const lines = await readTail(fp, 10);
+    expect(lines).toEqual(["a", "b"]);
+  });
+
+  it("returns empty array for empty file", async () => {
+    const fp = filePath("empty-tail.jsonl");
+    await fs.writeFile(fp, "");
+
+    const lines = await readTail(fp, 5);
+    expect(lines).toEqual([]);
+  });
+
+  it("handles file smaller than maxBytes", async () => {
+    const fp = filePath("tiny.jsonl");
+    await fs.writeFile(fp, "one\ntwo\nthree\n");
+
+    // maxBytes larger than file
+    const lines = await readTail(fp, 100, 1_000_000);
+    expect(lines).toEqual(["one", "two", "three"]);
+  });
+
+  it("reads only from the end of a large file", async () => {
+    const fp = filePath("large-tail.jsonl");
+    // Create a file where the last 100 bytes contain the tail
+    const manyLines = Array.from(
+      { length: 1000 },
+      (_, i) => `line-${String(i).padStart(4, "0")}`,
+    );
+    await fs.writeFile(fp, `${manyLines.join("\n")}\n`);
+
+    // Read last 100 bytes — should get only a few lines from the end
+    const lines = await readTail(fp, 100, 100);
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.length).toBeLessThan(20);
+    // Last line should be the final line
+    expect(lines[lines.length - 1]).toBe("line-0999");
+    // First line should NOT be the first line of the file
+    expect(lines[0]).not.toBe("line-0000");
+  });
+
+  it("drops partial first line when reading from middle of file", async () => {
+    const fp = filePath("partial-first.jsonl");
+    const manyLines = Array.from(
+      { length: 200 },
+      (_, i) => `line-${String(i).padStart(4, "0")}`,
+    );
+    await fs.writeFile(fp, `${manyLines.join("\n")}\n`);
+
+    // Read a small chunk — first line will be partial, should be dropped
+    const lines = await readTail(fp, 100, 60);
+    for (const l of lines) {
+      expect(l).toMatch(/^line-\d{4}$/);
+    }
+  });
+
+  it("works with JSON lines for token aggregation", async () => {
+    const fp = filePath("json-tail.jsonl");
+    const messages = Array.from({ length: 50 }, (_, i) =>
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          model: "claude-opus-4-6",
+          content: [{ type: "text", text: `Response ${i}` }],
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+      }),
+    );
+    await fs.writeFile(fp, `${messages.join("\n")}\n`);
+
+    const lines = await readTail(fp, 10);
+    expect(lines).toHaveLength(10);
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.message.model).toBe("claude-opus-4-6");
+    expect(last.message.usage.input_tokens).toBe(100);
+  });
+
+  it("handles file with no trailing newline", async () => {
+    const fp = filePath("notail-tail.jsonl");
+    await fs.writeFile(fp, "first\nsecond\nthird");
+
+    const lines = await readTail(fp, 2);
+    expect(lines).toEqual(["second", "third"]);
+  });
+});

--- a/src/utils/partial-read.ts
+++ b/src/utils/partial-read.ts
@@ -1,0 +1,79 @@
+import * as fs from "node:fs/promises";
+
+/**
+ * Read the first N lines of a file by reading only `maxBytes` from the start.
+ * Avoids allocating the entire file into memory for large JSONL files.
+ *
+ * @param filePath - Path to the file
+ * @param maxLines - Maximum number of lines to return
+ * @param maxBytes - Maximum bytes to read from the start (default 8192)
+ * @returns Array of complete lines (up to maxLines)
+ */
+export async function readHead(
+  filePath: string,
+  maxLines: number,
+  maxBytes = 8192,
+): Promise<string[]> {
+  const fh = await fs.open(filePath, "r");
+  try {
+    const stat = await fh.stat();
+    const bytesToRead = Math.min(maxBytes, stat.size);
+    if (bytesToRead === 0) return [];
+
+    const buf = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await fh.read(buf, 0, bytesToRead, 0);
+    if (bytesRead === 0) return [];
+
+    const text = buf.subarray(0, bytesRead).toString("utf-8");
+    const lines = text.split("\n");
+
+    // If we didn't read the whole file, the last chunk may be incomplete — drop it
+    if (bytesRead < stat.size) {
+      lines.pop();
+    }
+
+    return lines.filter((l) => l.length > 0).slice(0, maxLines);
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Read the last N lines of a file by reading only `maxBytes` from the end.
+ * Avoids allocating the entire file into memory for large JSONL files.
+ *
+ * @param filePath - Path to the file
+ * @param maxLines - Maximum number of lines to return
+ * @param maxBytes - Maximum bytes to read from the end (default 65536)
+ * @returns Array of complete lines (up to maxLines, in order)
+ */
+export async function readTail(
+  filePath: string,
+  maxLines: number,
+  maxBytes = 65536,
+): Promise<string[]> {
+  const fh = await fs.open(filePath, "r");
+  try {
+    const stat = await fh.stat();
+    if (stat.size === 0) return [];
+
+    const bytesToRead = Math.min(maxBytes, stat.size);
+    const offset = Math.max(0, stat.size - bytesToRead);
+
+    const buf = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await fh.read(buf, 0, bytesToRead, offset);
+    if (bytesRead === 0) return [];
+
+    const text = buf.subarray(0, bytesRead).toString("utf-8");
+    const lines = text.split("\n");
+
+    // If we didn't start from the beginning, the first chunk may be a partial line — drop it
+    if (offset > 0) {
+      lines.shift();
+    }
+
+    return lines.filter((l) => l.length > 0).slice(-maxLines);
+  } finally {
+    await fh.close();
+  }
+}


### PR DESCRIPTION
## Fixes #34

The agentctl daemon reads ~947MB of JSONL files every 5 seconds in its poll loop, causing 105% CPU and killing spawned Claude Code processes. Two hot code paths (`getEntriesForProject` and `parseSessionTail`) read entire files when they only need the first or last few lines.

### Changes

**Critical I/O fixes:**
- **`getEntriesForProject()`**: reads only first 8KB via `fs.open()` + `fileHandle.read()` instead of entire file (was reading up to 52MB per file just for 20 lines of session metadata)
- **`parseSessionTail()`**: reads only last 64KB instead of entire file (was reading up to 52MB for last 100 lines)

**Poll guard:**
- Added `polling` flag to `SessionTracker` so if the previous poll cycle is still running when the next interval fires, it skips instead of stacking up concurrent polls

**Stderr capture:**
- Changed `stdio: ["ignore", logFd.fd, "ignore"]` → `["ignore", logFd.fd, logFd.fd]` so stderr goes to the same log file for debugging launch failures

**State cleanup:**
- On daemon startup, prunes sessions from `state.json` that have been stopped for >7 days (521 stale sessions were adding overhead to every poll cycle)

**New `src/utils/partial-read.ts` module:**
- `readHead(path, maxLines, maxBytes)` — reads first N lines from first M bytes
- `readTail(path, maxLines, maxBytes)` — reads last N lines from last M bytes
- Handles edge cases: empty files, files smaller than maxBytes, no trailing newline, partial lines at buffer boundaries
- 14 unit tests

### Expected impact
- **Before**: ~947MB read per poll cycle (5s), 105% CPU
- **After**: ~few KB per file (8KB head + 64KB tail), negligible CPU

### Test plan
- [x] All 360 existing tests pass
- [x] 14 new tests for partial-read utilities
- [x] typecheck clean
- [x] lint clean