### PR TITLE
release: v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v1.2.0

### New Adapters
- **Codex** — `agentctl launch codex` (reads ~/.codex/sessions/)
- **OpenCode** — `agentctl launch opencode` (reads ~/.local/share/opencode/storage/)
- **Pi** — `agentctl launch pi` (reads ~/.pi/agent/sessions/ JSONL)
- **Pi Rust** — `agentctl launch pi-rust` (reads ~/.pi/agent/sessions/)

### Parallel Multi-Adapter Launch
- `agentctl launch --adapter A --adapter B -p 'prompt'` — each gets its own worktree
- `--adapter claude-code --model opus --adapter claude-code --model sonnet` — same adapter, different models
- `--matrix config.yaml` — YAML matrix files with cross-product expansion
- Groups: sessions tagged with group ID, GROUP column in `list`
- `agentctl worktree list <repo>` and `agentctl worktree clean <path>`
- Decision record: `docs/decisions/001-parallel-multi-adapter-launch.md`

### Performance
- **Critical fix**: Daemon was reading ~947MB of JSONL every 5s poll cycle (105% CPU). Now reads only first 8KB/last 64KB per file. CPU: 105% → 2.4%.
- Poll guard: skip cycle if previous still running
- Partial read utilities: `readHead()` and `readTail()` in src/utils/partial-read.ts

### Hooks
- `AGENTCTL_GROUP` and `AGENTCTL_MODEL` env vars in hook context