### PR TITLE
fix: daemon reliability improvements (#39, #40, #41, #42)

### DIFF
--- a/src/utils/daemon-env.ts
+++ b/src/utils/daemon-env.ts
@@ -1,0 +1,101 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ENV_FILE = "daemon-env.json";
+
+/**
+ * Common bin directories that should be in PATH when spawning subprocesses.
+ * These cover the usual locations for various package managers and tools.
+ */
+function getCommonBinDirs(): string[] {
+  const home = os.homedir();
+  return [
+    path.join(home, ".local", "bin"),
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+    "/opt/homebrew/bin",
+    path.join(home, ".npm-global", "bin"),
+    path.join(home, ".local", "share", "mise", "shims"),
+    path.join(home, ".cargo", "bin"),
+  ];
+}
+
+/**
+ * Save the current process environment to disk.
+ * Called at daemon start time when we still have the user's shell env.
+ */
+export async function saveEnvironment(configDir: string): Promise<void> {
+  const envPath = path.join(configDir, ENV_FILE);
+  try {
+    const tmpPath = `${envPath}.tmp`;
+    await fs.writeFile(tmpPath, JSON.stringify(process.env));
+    await fs.rename(tmpPath, envPath);
+  } catch (err) {
+    console.error(
+      `Warning: could not save environment: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Load the saved environment from disk.
+ * Returns undefined if the env file doesn't exist or is corrupt.
+ */
+export async function loadSavedEnvironment(
+  configDir: string,
+): Promise<Record<string, string> | undefined> {
+  const envPath = path.join(configDir, ENV_FILE);
+  try {
+    const raw = await fs.readFile(envPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // File doesn't exist or is corrupt
+  }
+  return undefined;
+}
+
+/**
+ * Build an augmented environment for spawning subprocesses.
+ * Merges the saved daemon env with common bin paths to ensure
+ * binaries are findable even when the daemon is detached from the shell.
+ */
+export function buildSpawnEnv(
+  savedEnv?: Record<string, string>,
+  extraEnv?: Record<string, string>,
+): Record<string, string> {
+  const base: Record<string, string> = {};
+  const source = savedEnv || (process.env as Record<string, string>);
+
+  // Copy source env
+  for (const [k, v] of Object.entries(source)) {
+    if (v !== undefined) base[k] = v;
+  }
+
+  // Augment PATH with common bin directories
+  const existingPath = base.PATH || "";
+  const existingDirs = new Set(existingPath.split(":").filter(Boolean));
+  const commonDirs = getCommonBinDirs();
+  const newDirs = commonDirs.filter((d) => !existingDirs.has(d));
+
+  if (newDirs.length > 0) {
+    base.PATH = [...existingPath.split(":").filter(Boolean), ...newDirs].join(
+      ":",
+    );
+  }
+
+  // Apply extra env overrides
+  if (extraEnv) {
+    for (const [k, v] of Object.entries(extraEnv)) {
+      base[k] = v;
+    }
+  }
+
+  return base;
+}

--- a/src/utils/resolve-binary.ts
+++ b/src/utils/resolve-binary.ts
@@ -1,0 +1,76 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Cache of resolved binary paths: name → absolute path */
+const resolvedCache = new Map<string, string>();
+
+/**
+ * Resolve the absolute path to a binary, checking known locations first,
+ * then falling back to `which`. Results are cached per binary name.
+ *
+ * @param name - Binary name (e.g., "claude", "codex", "pi")
+ * @param knownLocations - Additional absolute paths to check first
+ * @returns Resolved absolute path, or bare name as last resort
+ */
+export async function resolveBinaryPath(
+  name: string,
+  knownLocations: string[] = [],
+): Promise<string> {
+  const cached = resolvedCache.get(name);
+  if (cached) return cached;
+
+  const home = os.homedir();
+
+  // Default well-known locations for common toolchains
+  const defaultLocations = [
+    path.join(home, ".local", "bin", name),
+    `/usr/local/bin/${name}`,
+    `/opt/homebrew/bin/${name}`, // Homebrew Apple Silicon
+    path.join(home, ".npm-global", "bin", name),
+    path.join(home, ".local", "share", "mise", "shims", name),
+    path.join(home, ".cargo", "bin", name),
+  ];
+
+  const candidates = [...knownLocations, ...defaultLocations];
+
+  for (const c of candidates) {
+    try {
+      await fs.access(c, fs.constants.X_OK);
+      // Resolve symlinks to get the actual binary path
+      const resolved = await fs.realpath(c);
+      await fs.access(resolved, fs.constants.X_OK);
+      resolvedCache.set(name, resolved);
+      return resolved;
+    } catch {
+      // Try next
+    }
+  }
+
+  // Try `which <name>` as fallback
+  try {
+    const { stdout } = await execFileAsync("which", [name]);
+    const p = stdout.trim();
+    if (p) {
+      resolvedCache.set(name, p);
+      return p;
+    }
+  } catch {
+    // Fall through
+  }
+
+  // Last resort: bare name (let PATH resolve it at spawn time)
+  return name;
+}
+
+/**
+ * Clear the resolved path cache. Call this when binaries may have been
+ * updated (e.g., on daemon restart).
+ */
+export function clearBinaryCache(): void {
+  resolvedCache.clear();
+}


### PR DESCRIPTION
## Summary

Makes the agentctl daemon robust against real-world failure modes:

- **#39 — Singleton enforcement**: Kill stale daemon/supervisor processes from PID files *and* via `ps` scan on startup. Verify socket liveness before refusing to start. Proper cleanup ordering prevents orphan daemons.

- **#40 — Session state cleanup**: Validate all "running" sessions on daemon startup — mark dead PIDs as stopped immediately. Add `agentctl prune` command for aggressive dead session removal (stopped >24h, dead PIDs). Enhanced `daemon status` shows supervisor and daemon PIDs.

- **#41 — Binary resolution**: Shared `resolveBinaryPath()` utility used by all 5 spawning adapters. Resolves symlinks via `fs.realpath()`, checks known install locations, caches resolved paths, falls back to `which`. Added `.on('error')` spawn handlers to every adapter's `launch()` and `resume()` methods.

- **#42 — Environment preservation**: Save shell environment to `daemon-env.json` on daemon start. `buildSpawnEnv()` augments PATH with common bin directories (`/usr/local/bin`, Homebrew, `~/.local/bin`, etc.) when spawning agent subprocesses from the detached daemon.

Fixes #39, Fixes #40, Fixes #41, Fixes #42

## Changed files

| File | Change |
|------|--------|
| `src/utils/resolve-binary.ts` | **New** — shared binary resolution + caching |
| `src/utils/daemon-env.ts` | **New** — environment save/load/augment for daemon spawns |
| `src/daemon/server.ts` | Stale process cleanup, socket liveness check, session prune RPC |
| `src/daemon/session-tracker.ts` | `validateAllSessions()`, `pruneDeadSessions()` |
| `src/cli.ts` | `agentctl prune` command, enhanced `daemon status` |
| `src/adapters/claude-code.ts` | Use shared `resolveBinaryPath` + `buildSpawnEnv` |
| `src/adapters/codex.ts` | Use shared utils, add spawn error handlers |
| `src/adapters/opencode.ts` | Use shared utils, add spawn error handlers |
| `src/adapters/pi.ts` | Use shared utils, add spawn error handlers |
| `src/adapters/pi-rust.ts` | Use shared utils, add spawn error handlers |

## Test plan

- [x] `npm run lint` — passes (biome check)
- [x] `npm run typecheck` — passes (tsc --noEmit)
- [x] `npm test` — all 389 tests pass
- [x] Pre-push hook validates lint + typecheck + build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)