### PR TITLE
feat: add Adapter column to agentctl list

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,7 @@ function formatSession(
   const row: Record<string, string> = {
     ID: s.id.slice(0, 8),
     Status: s.status,
+    Adapter: s.adapter || "-",
     Model: s.model || "-",
   };
   if (showGroup) row.Group = s.group || "-";
@@ -129,6 +130,7 @@ function formatRecord(
   const row: Record<string, string> = {
     ID: s.id.slice(0, 8),
     Status: s.status,
+    Adapter: s.adapter || "-",
     Model: s.model || "-",
   };
   if (showGroup) row.Group = s.group || "-";


### PR DESCRIPTION
Adds an `Adapter` column to `agentctl list` output so you can immediately see which adapter owns each session (claude-code, openclaw, pi, etc.).

Before:
```
ID        Status   Model              CWD  PID  Started  Prompt
```

After:
```
ID        Status   Adapter      Model              CWD  PID  Started  Prompt
```

389 tests pass.