### PR TITLE
feat: implement discover-first session tracking (ADR-002 Phase 2+3)

### DIFF
--- a/docs/decisions/002-discover-first-session-tracking.md
+++ b/docs/decisions/002-discover-first-session-tracking.md
@@ -1,7 +1,7 @@
 # ADR-002: Discover-First Session Tracking
 
-**Status:** Proposed  
-**Date:** 2026-02-23  
+**Status:** Accepted
+**Date:** 2026-02-23
 **Author:** Doink + Charlie  
 **Relates to:** Issues #37, #39, #40, #41, #42
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,9 +1,35 @@
 // agentctl core types — Universal Agent Supervision Interface
 
+/**
+ * Session discovered by an adapter's runtime — the ground truth for "what exists."
+ * This is the source of truth for session lifecycle in the discover-first model.
+ */
+export interface DiscoveredSession {
+  id: string;
+  status: "running" | "stopped";
+  adapter: string;
+  cwd?: string;
+  model?: string;
+  startedAt?: Date;
+  stoppedAt?: Date;
+  pid?: number;
+  prompt?: string;
+  tokens?: { in: number; out: number };
+  cost?: number;
+  /** Adapter-native fields — whatever the runtime provides */
+  nativeMetadata?: Record<string, unknown>;
+}
+
 export interface AgentAdapter {
   id: string; // "claude-code", "openclaw", etc.
 
-  // Discovery
+  // Discover-first: ground truth from adapter runtime
+  /** Find all sessions currently managed by this adapter's runtime. */
+  discover(): Promise<DiscoveredSession[]>;
+  /** Check if a specific session is still alive. */
+  isAlive(sessionId: string): Promise<boolean>;
+
+  // Legacy discovery (delegates to discover() with filtering)
   list(opts?: ListOpts): Promise<AgentSession[]>;
 
   // Read


### PR DESCRIPTION
## Summary

Implements the discover-first architecture from ADR-002, shifting session lifecycle authority from daemon state to adapter-native discovery.

- **All 6 adapters** now implement `discover()` and `isAlive()` — the adapter contract from ADR-002
  - `claude-code`: reads `~/.claude/projects/` JSONL + PID check
  - `codex`: reads `~/.codex/sessions/` + PID check
  - `openclaw`: queries gateway API `sessions.list`
  - `opencode`: reads `~/.local/share/opencode/storage/` + PID check
  - `pi`: reads `~/.pi/` session files + PID check
  - `pi-rust`: reads `~/.pi/agent/sessions/` + PID check
- **Daemon session tracker** (`poll()`) now calls `adapter.discover()` instead of `adapter.list()` — adapters are the source of truth
- **CLI direct fallback** (`agentctl list` without daemon) uses `adapter.discover()` with status filtering
- **Core types** extended with `DiscoveredSession` interface and updated `AgentAdapter` contract
- **ADR-002** status updated from Proposed → Accepted

### How this fixes the bug classes from ADR-002

| Bug | Fix |
|-----|-----|
| Ghost sessions (#40) | `discover()` only returns what's actually alive |
| Multiple daemons (#39) | No daemon state to duplicate — adapters are stateless |
| Stale state after crashes | Restart → rediscover → zero data loss |

### What's NOT in this PR (future work)

- Metadata store for launch prompts/labels (Phase 4 concern)
- Caching layer for `discover()` results (optimization)
- Remove state-based lifecycle tracking entirely (Phase 4)

## Test plan

- [x] All 389 existing tests pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Session tracker test updated with discover-first mock adapter
- [ ] Manual: `agentctl list` returns accurate sessions via discover-first path
- [ ] Manual: Daemon poll cycle correctly reconciles discovered sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)