### PR TITLE
fix: omit undefined fields in lock error messages

### DIFF
--- a/src/daemon/lock-manager.ts
+++ b/src/daemon/lock-manager.ts
@@ -55,7 +55,7 @@ export class LockManager {
     const existing = this.check(resolved);
     if (existing?.type === "manual") {
       throw new Error(
-        `Already manually locked by ${existing.lockedBy}: ${existing.reason}`,
+        `Already manually locked by ${existing.lockedBy ?? "unknown"}${existing.reason ? `: ${existing.reason}` : ""}`,
       );
     }
     const lock: Lock = {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -497,7 +497,7 @@ function createRequestHandler(ctx: HandlerContext) {
         if (lock && !params.force) {
           if (lock.type === "manual") {
             throw new Error(
-              `Directory locked by ${lock.lockedBy}: ${lock.reason}. Use --force to override.`,
+              `Directory locked by ${lock.lockedBy ?? "unknown"}${lock.reason ? `: ${lock.reason}` : ""}. Use --force to override.`,
             );
           }
           throw new Error(


### PR DESCRIPTION
## Summary
- Fixed lock error messages showing "Directory locked by ms: undefined" when no reason was provided
- Both `server.ts` (launch lock check) and `lock-manager.ts` (double-lock check) now gracefully omit the reason clause when absent and fall back to "unknown" for missing `lockedBy`

Fixes #58

## Test plan
- [x] `npm run typecheck` passes
- [x] All 388 tests pass
- [ ] Manual: `agentctl lock /tmp/test && agentctl launch claude-code --cwd /tmp/test -p test` shows clean message without "undefined"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Charlie Hulcher <charlie@kindo.ai>