### PR TITLE
fix: omit undefined fields in lock error messages

### DIFF
--- a/src/daemon/lock-manager.ts
+++ b/src/daemon/lock-manager.ts
@@ -55,7 +55,7 @@ export class LockManager {
     const existing = this.check(resolved);
     if (existing?.type === "manual") {
       throw new Error(
-        `Already manually locked by ${existing.lockedBy}: ${existing.reason}`,
+        `Already manually locked by ${existing.lockedBy ?? "unknown"}${existing.reason ? `: ${existing.reason}` : ""}`,
       );
     }
     const lock: Lock = {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -497,7 +497,7 @@ function createRequestHandler(ctx: HandlerContext) {
         if (lock && !params.force) {
           if (lock.type === "manual") {
             throw new Error(
-              `Directory locked by ${lock.lockedBy}: ${lock.reason}. Use --force to override.`,
+              `Directory locked by ${lock.lockedBy ?? "unknown"}${lock.reason ? `: ${lock.reason}` : ""}. Use --force to override.`,
             );
           }
           throw new Error(


### PR DESCRIPTION
Fixes #58

Lock error messages were showing 'by ms: undefined' when reason was not set. Now omits undefined fields for cleaner output.