### PR TITLE
fix: make on-create hook defaults sane

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -94,14 +94,14 @@ describe("runHook", () => {
     expect(result?.stdout.trim()).toBe("claude-opus-4-6");
   });
 
-  it("handles hook script failures gracefully", async () => {
+  it("throws when hook script fails", async () => {
     const hooks: LifecycleHooks = { onCreate: "exit 1" };
-    const result = await runHook(hooks, "onCreate", {
-      ...defaultCtx,
-      cwd: tmpDir,
-    });
-    // Should not throw, returns result with stderr
-    expect(result).not.toBeNull();
+    await expect(
+      runHook(hooks, "onCreate", {
+        ...defaultCtx,
+        cwd: tmpDir,
+      }),
+    ).rejects.toThrow("Hook onCreate failed:");
   });
 
   it("runs onComplete hook", async () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -47,12 +47,11 @@ export async function runHook(
     const result = await execAsync(script, {
       cwd: ctx.cwd,
       env,
-      timeout: 60_000,
+      timeout: 300_000,
     });
     return { stdout: result.stdout, stderr: result.stderr };
   } catch (err) {
     const e = err as Error & { stdout?: string; stderr?: string };
-    console.error(`Hook ${phase} failed:`, e.message);
-    return { stdout: e.stdout || "", stderr: e.stderr || "" };
+    throw new Error(`Hook ${phase} failed: ${e.message}`);
   }
 }


### PR DESCRIPTION
## Summary
- Increase default `--on-create` hook timeout from 60s to 300s (5 minutes) for large monorepo installs
- Make hook failures throw instead of being silently swallowed, so a failed on-create hook aborts the launch rather than starting the agent in a broken worktree
- Update test to expect throw on hook failure

Fixes #55

## Test plan
- [x] `npm test` — all 388 tests pass
- [x] `npm run typecheck` — clean
- [x] Pre-push hooks pass (lint, typecheck, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)