### PR TITLE
release: v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v1.5.0

### Bug Fixes
- **fix: resolve pending- session IDs** so peek/stop/resume work (#63, fixes #60)
- **fix: omit undefined fields** in lock error messages (#66, fixes #58)
- **fix: sane on-create hook defaults** — 300s timeout, abort on failure (#68, fixes #55)

### Features
- **feat: `logs` command** as alias for `peek` with 50-line default (#62, fixes #57)

### Docs
- **docs: document default --cwd behavior** (#64, fixes #59)

### Notes
All 404 tests pass. Smoke tested locally.