### PR TITLE
chore: add release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [1.5.0] - 2026-02-26
+
+### Added
+
+- `logs` command as alias for `peek` (#62)
+
+### Fixed
+
+- Resolve pending- session IDs so `peek`/`stop`/`resume` work (#60, #63)
+- Make on-create hook defaults sane (#68)
+- Omit undefined fields in lock error messages (#61, #65, #66)
+
+### Docs
+
+- Document default `--cwd` behavior (#64)
+
+## [1.4.0] - 2026-02-24
+
+### Added
+
+- Stateless daemon core (Phases 1-3) (#52)
+
+## [1.3.0] - 2026-02-23
+
+### Added
+
+- CLI surface cleanup per ADR-003 (#49)
+- Discover-first session tracking (ADR-002 Phase 2+3) (#46)
+
+### Docs
+
+- ADR-002: discover-first session tracking
+- ADR-003: CLI surface and design principles
+
+## [1.2.1] - 2026-02-23
+
+### Added
+
+- Adapter column to `agentctl list` output (#44)
+
+### Fixed
+
+- Improve daemon reliability across binary resolution, env, singleton, and session cleanup (#43)
+- Resolve claude binary path and handle spawn errors gracefully (#38)
+
+### Docs
+
+- ADR-002: discover-first session tracking
+
+## [1.2.0] - 2026-02-23
+
+### Added
+
+- Parallel multi-adapter launch (#33)
+- Pi coding agent adapter (#32)
+- OpenCode adapter for session discovery and control (#31)
+- Codex CLI adapter (#29)
+- Pi Rust adapter (#30)
+- Ed25519 device auth for scoped gateway access (#26)
+
+### Fixed
+
+- Reduce daemon CPU saturation from full JSONL reads (#35)
+- Reconcile pending-PID ghosts and add liveness checks (#28)
+- Fix gateway handshake params and auth token resolution (#25)
+
+## [1.1.0] - 2026-02-20
+
+### Fixed
+
+- Reap ghost sessions and deduplicate pending-* entries (#23)
+
+## [1.0.1] - 2026-02-20
+
+### Fixed
+
+- Address docs issues #11-#17 (#19)
+
+## [1.0.0] - 2026-02-20
+
+### Added
+
+- Core agentctl CLI with Claude Code adapter
+- OpenClaw gateway adapter (#2)
+- Daemon with locks, fuses, metrics (#5)
+- Session lifecycle management with PID tracking (#4)
+- PID recycling detection via process start time (#3)
+- Session lifecycle bug fixes and feature queue (#7)
+- Public release preparation (#6, #8)
+
+### Fixed
+
+- Match GitHub org casing for npm provenance (#10)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing agentctl
+
+## Quick Release
+
+```bash
+bash scripts/release.sh --patch|--minor|--major
+```
+
+This script handles the full release flow:
+
+1. Calculates the new version from the current `package.json`
+2. Creates a `release/vX.Y.Z` branch from `origin/main`
+3. Bumps version via `npm version` (no git tag)
+4. Prompts to edit `CHANGELOG.md` (or pass `--changelog "entry"`)
+5. Runs `npm run build` and `npm test`
+6. Commits and pushes the branch
+7. Opens a PR via `gh-me`
+
+## Post-Merge
+
+After the release PR is merged:
+
+```bash
+git checkout main && git pull origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag push triggers the npm publish workflow (GitHub Actions).
+
+After publish is confirmed:
+
+```bash
+# Rebuild and relink locally
+npm run build && npm link --force
+agentctl --version  # verify
+```
+
+## Version Bump Guide
+
+| Bump    | When                                         |
+| ------- | -------------------------------------------- |
+| `patch` | Bug fixes, docs improvements                 |
+| `minor` | New features, non-breaking changes           |
+| `major` | Breaking changes (discuss with Charlie first) |
+
+## Key Notes
+
+- **Never commit directly to main** — all changes go through PRs
+- **Never force push** to any branch
+- **Use `gh-me`** (not `gh`) for all GitHub operations
+- npm provenance requires exact GitHub org casing (`OrgLoop` not `orgloop` in `package.json`)
+- CLI version reads from `package.json` at runtime — no manual update needed
+- Pre-push hooks run lint/typecheck/build/test — don't skip them

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,39 +1,140 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUMP="${1:-patch}"
+# agentctl release script
+# Creates a release branch, bumps version, updates changelog, builds, tests, and opens a PR.
+# NEVER commits to main. NEVER force pushes.
 
-if [[ "$BUMP" != "patch" && "$BUMP" != "minor" && "$BUMP" != "major" ]]; then
-  echo "Usage: $0 [patch|minor|major]"
+usage() {
+  echo "Usage: $0 --patch|--minor|--major [--changelog \"entry\"]"
+  echo ""
+  echo "Options:"
+  echo "  --patch           Bump patch version (0.0.X)"
+  echo "  --minor           Bump minor version (0.X.0)"
+  echo "  --major           Bump major version (X.0.0)"
+  echo "  --changelog TEXT  Changelog entry (skips \$EDITOR prompt)"
+  echo "  --dry-run         Show what would happen without making changes"
+  exit 1
+}
+
+BUMP=""
+CHANGELOG_ENTRY=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --patch) BUMP="patch"; shift ;;
+    --minor) BUMP="minor"; shift ;;
+    --major) BUMP="major"; shift ;;
+    --changelog) CHANGELOG_ENTRY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) usage ;;
+  esac
+done
+
+[[ -z "$BUMP" ]] && usage
+
+# Must be run from repo root
+if [[ ! -f "package.json" ]]; then
+  echo "❌ Must be run from the repository root"
   exit 1
 fi
 
 # Ensure clean working tree
 if [[ -n "$(git status --porcelain)" ]]; then
-  echo "Error: working tree is not clean. Commit or stash changes first."
+  echo "❌ Working tree is not clean. Commit or stash changes first."
   exit 1
 fi
 
+# Calculate new version
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "$BUMP" in
+  major) NEW_VERSION="$((MAJOR + 1)).0.0" ;;
+  minor) NEW_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+  patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+esac
+
+BRANCH="release/v${NEW_VERSION}"
+echo "📦 Releasing v${NEW_VERSION} (${BUMP} bump from ${CURRENT_VERSION})"
+
+if $DRY_RUN; then
+  echo "🏜️  Dry run — would create branch ${BRANCH}, bump to ${NEW_VERSION}"
+  exit 0
+fi
+
+# Create release branch from origin/main
+git fetch origin main
+git checkout -b "$BRANCH" origin/main
+echo "🌿 Created branch ${BRANCH}"
+
 # Bump version
-NEW_VERSION=$(npm version "$BUMP" --no-git-tag-version)
-echo "Bumped to $NEW_VERSION"
+npm version "$NEW_VERSION" --no-git-tag-version
+echo "📝 Bumped package.json to ${NEW_VERSION}"
+
+# Update CHANGELOG.md
+if [[ -n "$CHANGELOG_ENTRY" ]]; then
+  DATE=$(date +%Y-%m-%d)
+  ENTRY="\n## [${NEW_VERSION}] - ${DATE}\n\n${CHANGELOG_ENTRY}\n"
+  node -e "
+    const fs = require('fs');
+    let cl = fs.readFileSync('CHANGELOG.md', 'utf8');
+    cl = cl.replace('## [Unreleased]', '## [Unreleased]\n${ENTRY}');
+    fs.writeFileSync('CHANGELOG.md', cl);
+  "
+  echo "📋 Updated CHANGELOG.md"
+else
+  echo ""
+  echo "📋 Opening CHANGELOG.md for editing..."
+  echo "   Add an entry under [Unreleased] for version ${NEW_VERSION}"
+  echo ""
+  ${EDITOR:-vi} CHANGELOG.md
+fi
 
 # Build and test
+echo "🔨 Building..."
 npm run build
+
+echo "🧪 Testing..."
 npm test
 
-# Link locally
-npm link
-
-# Commit and tag
-git add package.json package-lock.json
-git commit --author="Doink (OpenClaw) <charlie+doink@kindo.ai>" -m "release: $NEW_VERSION
+# Commit
+git add -A
+git commit --author="Doink (OpenClaw) <charlie+doink@kindo.ai>" -m "release: v${NEW_VERSION}
 
 Co-Authored-By: Charlie Hulcher <charlie@kindo.ai>"
-git tag "v$NEW_VERSION"
 
-# Push with tag (triggers publish workflow)
-git push origin main --tags
+# Push branch (never force push)
+git push origin "$BRANCH"
+echo "🚀 Pushed ${BRANCH}"
+
+# Open PR
+gh-me pr create \
+  --title "release: v${NEW_VERSION}" \
+  --body "## Release v${NEW_VERSION}
+
+- Version bump: ${CURRENT_VERSION} → ${NEW_VERSION} (${BUMP})
+- CHANGELOG.md updated
+- Build + tests passed
+
+### Post-merge steps
+
+\`\`\`bash
+git checkout main && git pull origin main
+git tag v${NEW_VERSION}
+git push origin v${NEW_VERSION}
+\`\`\`
+
+Tag push triggers the npm publish workflow." \
+  --head "$BRANCH" \
+  --base main
 
 echo ""
-echo "✅ Released $NEW_VERSION — publish workflow triggered."
+echo "✅ PR opened for v${NEW_VERSION}"
+echo ""
+echo "📌 After PR is merged:"
+echo "   git checkout main && git pull origin main"
+echo "   git tag v${NEW_VERSION}"
+echo "   git push origin v${NEW_VERSION}"
+echo "   # Tag push triggers npm publish workflow"


### PR DESCRIPTION
## Summary

- **Backfill CHANGELOG.md** with entries for v1.0.0 through v1.5.0 using Keep a Changelog format
- **Rewrite `scripts/release.sh`** to use PR-based flow — creates release branch, bumps version, opens PR via `gh-me`. Never commits to main, never force pushes. (Previous version committed directly to main.)
- **Add RELEASING.md** documenting the full release process

No functional changes.