### PR TITLE
release: v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release with P0+P1 fixes from PR #76:
- fix: --adapter flag routing (#74)
- fix: pending ID display truncation (#71)
- fix: check-cancelled SOP reference (#75)
- fix: OpenClaw stale session classification (#72)
- fix: silent adapter timeout omission (#73)