### PR TITLE
fix: opencode detach, matrix prompt override, persistent config defaults

### DIFF
--- a/src/matrix-parser.test.ts
+++ b/src/matrix-parser.test.ts
@@ -64,8 +64,8 @@ matrix:
     ]);
   });
 
-  it("throws on missing prompt", async () => {
-    const filePath = path.join(tmpDir, "bad.yaml");
+  it("allows missing prompt (CLI -p can provide it)", async () => {
+    const filePath = path.join(tmpDir, "no-prompt.yaml");
     await fs.writeFile(
       filePath,
       `
@@ -74,8 +74,24 @@ matrix:
 `,
     );
 
+    const result = await parseMatrixFile(filePath);
+    expect(result.prompt).toBeUndefined();
+    expect(result.matrix).toHaveLength(1);
+  });
+
+  it("throws on non-string prompt", async () => {
+    const filePath = path.join(tmpDir, "bad.yaml");
+    await fs.writeFile(
+      filePath,
+      `
+prompt: 123
+matrix:
+  - adapter: claude-code
+`,
+    );
+
     await expect(parseMatrixFile(filePath)).rejects.toThrow(
-      "must have a 'prompt' field",
+      "'prompt' field must be a string",
     );
   });
 

--- a/src/matrix-parser.ts
+++ b/src/matrix-parser.ts
@@ -12,7 +12,7 @@ export interface MatrixEntry {
 
 /** Top-level matrix file schema */
 export interface MatrixFile {
-  prompt: string;
+  prompt?: string;
   cwd?: string;
   spec?: string;
   hooks?: {
@@ -49,8 +49,8 @@ export async function parseMatrixFile(filePath: string): Promise<MatrixFile> {
     throw new Error(`Invalid matrix file: ${filePath}`);
   }
 
-  if (!parsed.prompt || typeof parsed.prompt !== "string") {
-    throw new Error("Matrix file must have a 'prompt' field (string)");
+  if (parsed.prompt !== undefined && typeof parsed.prompt !== "string") {
+    throw new Error("Matrix file 'prompt' field must be a string");
   }
 
   if (!Array.isArray(parsed.matrix) || parsed.matrix.length === 0) {

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadConfig } from "./config.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentctl-config-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadConfig", () => {
+  it("returns empty object when config file does not exist", async () => {
+    const config = await loadConfig(path.join(tmpDir, "nope.json"));
+    expect(config).toEqual({});
+  });
+
+  it("parses valid config JSON", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ model: "opus", adapter: "claude-code", timeout: 300 }),
+    );
+
+    const config = await loadConfig(configPath);
+    expect(config.model).toBe("opus");
+    expect(config.adapter).toBe("claude-code");
+    expect(config.timeout).toBe(300);
+  });
+
+  it("returns empty object for malformed JSON", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.writeFile(configPath, "not valid json{{{");
+
+    const config = await loadConfig(configPath);
+    expect(config).toEqual({});
+  });
+
+  it("returns empty object for non-object JSON (array)", async () => {
+    const configPath = path.join(tmpDir, "config.json");
+    await fs.writeFile(configPath, "[1, 2, 3]");
+
+    const config = await loadConfig(configPath);
+    expect(config).toEqual({});
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,36 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** Persistent config defaults loaded from ~/.agentctl/config.json */
+export interface AgentCtlConfig {
+  adapter?: string;
+  model?: string;
+  cwd?: string;
+  timeout?: number;
+}
+
+export const DEFAULT_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".agentctl",
+  "config.json",
+);
+
+/**
+ * Load config defaults from ~/.agentctl/config.json (or a custom path).
+ * Returns an empty object if the file doesn't exist or is malformed.
+ */
+export async function loadConfig(
+  configPath = DEFAULT_CONFIG_PATH,
+): Promise<AgentCtlConfig> {
+  try {
+    const raw = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as AgentCtlConfig;
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix #86**: OpenCode adapter used `stdio: ["ignore", "pipe", "pipe"]` which kept pipes open, preventing full process detachment. Now writes to log file fd (matching claude-code adapter pattern) and closes immediately. Also fixes the same issue in `resume()`.
- **Fix #84**: `--matrix` prompt was overridden by required `-p` flag. Made `-p` optional; matrix file prompt used as fallback when `-p` is omitted. Matrix parser no longer requires `prompt` field (can be supplied via CLI).  
- **Fix #67**: Added `~/.agentctl/config.json` support for persistent CLI defaults (`adapter`, `model`, `cwd`, `timeout`). CLI flags override config values.

## Test plan

- [x] All 433 existing tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] New tests for config loader (4 tests: missing file, valid JSON, malformed JSON, non-object JSON)
- [x] Updated matrix-parser tests (prompt now optional, validates non-string prompt type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)