### PR TITLE
release: v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Changes since v1.5.1

- fix: opencode detach, matrix prompt override, persistent config defaults (#87)
- fix: worktree slug collisions, pi-rust --provider/--append-system-prompt (#83)
- fix: pass --model flag when launching opencode (#79)

All bug fixes. 433/433 tests passing.