### PR TITLE
fix: peek/status timeout on opencode sessions

### DIFF
--- a/src/adapters/opencode.test.ts
+++ b/src/adapters/opencode.test.ts
@@ -493,12 +493,64 @@ describe("OpenCodeAdapter", () => {
       const output = await adapter.peek(session.id);
       expect(output).toContain("Content field text");
     });
+
+    it("only reads parts for the last N assistant messages (not all)", async () => {
+      // Regression test: peek should NOT read parts for messages outside
+      // the requested window. With 50 assistant messages and lines=3, only
+      // the last 3 should have their parts read.
+      const session = makeSession();
+      const messages: OpenCodeMessageFile[] = [];
+      const parts: Record<
+        string,
+        Array<{ file: string; content: string }>
+      > = {};
+
+      for (let i = 0; i < 50; i++) {
+        const msgId = `msg-bulk-${i.toString().padStart(3, "0")}`;
+        messages.push(
+          makeMessage({
+            id: msgId,
+            role: "assistant",
+            time: {
+              created: new Date(Date.now() + i * 1000).toISOString(),
+              completed: new Date(Date.now() + i * 1000 + 500).toISOString(),
+            },
+          }),
+        );
+        parts[msgId] = [
+          {
+            file: "part-001.json",
+            content: JSON.stringify({ text: `Bulk message ${i}` }),
+          },
+        ];
+      }
+
+      await createFakeSession(
+        session.directory || "",
+        session,
+        messages,
+        parts,
+      );
+
+      const output = await adapter.peek(session.id, { lines: 3 });
+      // Should contain only the last 3 messages
+      expect(output).toContain("Bulk message 47");
+      expect(output).toContain("Bulk message 48");
+      expect(output).toContain("Bulk message 49");
+      // Should NOT contain earlier messages
+      expect(output).not.toContain("Bulk message 0");
+      expect(output).not.toContain("Bulk message 46");
+    });
   });
 
   describe("status()", () => {
     it("returns session details", async () => {
       const session = makeSession({
         title: "Status check session",
+        time: {
+          created: new Date(Date.now() - 3600_000).toISOString(),
+          updated: new Date(Date.now() - 120_000).toISOString(),
+        },
       });
       const msg = makeMessage({
         model: {
@@ -536,6 +588,65 @@ describe("OpenCodeAdapter", () => {
 
       const result = await adapter.status("abcdef99");
       expect(result.id).toBe("abcdef99-1111-2222-3333-444444444444");
+    });
+
+    it("detects running session via persisted metadata without getPids", async () => {
+      // status() should use lightweight PID check (persisted meta + isProcessAlive)
+      // instead of expensive getOpenCodePids() (ps aux + lsof per process)
+      const session = makeSession({
+        id: "running-status-0000-1111-222222222222",
+        time: {
+          created: new Date(Date.now() - 3600_000).toISOString(),
+          // Updated long ago — NOT recently, so recency heuristic won't trigger
+          updated: new Date(Date.now() - 3600_000).toISOString(),
+        },
+      });
+      await createFakeSession(session.directory || "", session);
+
+      // Write persisted session metadata with a fake PID
+      const meta: LaunchedSessionMeta = {
+        sessionId: session.id,
+        pid: 99999,
+        cwd: session.directory || "",
+        launchedAt: new Date(Date.now() - 3600_000).toISOString(),
+      };
+      await fs.writeFile(
+        path.join(sessionsMetaDir, `${session.id}.json`),
+        JSON.stringify(meta),
+      );
+
+      // Create adapter where getPids is never called but isProcessAlive returns true
+      let getPidsCalled = false;
+      const aliveAdapter = new OpenCodeAdapter({
+        storageDir,
+        sessionsMetaDir,
+        getPids: async () => {
+          getPidsCalled = true;
+          return new Map();
+        },
+        isProcessAlive: (pid) => pid === 99999,
+      });
+
+      const result = await aliveAdapter.status(session.id);
+      expect(result.status).toBe("running");
+      expect(result.pid).toBe(99999);
+      // status() should NOT call getPids — that's the whole optimization
+      expect(getPidsCalled).toBe(false);
+    });
+
+    it("detects running session via recent update heuristic", async () => {
+      const session = makeSession({
+        id: "recent-status-0000-1111-222222222222",
+        time: {
+          created: new Date(Date.now() - 3600_000).toISOString(),
+          // Updated 10 seconds ago — recency heuristic should trigger
+          updated: new Date(Date.now() - 10_000).toISOString(),
+        },
+      });
+      await createFakeSession(session.directory || "", session);
+
+      const result = await adapter.status(session.id);
+      expect(result.status).toBe("running");
     });
   });
 

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -276,30 +276,69 @@ export class OpenCodeAdapter implements AgentAdapter {
 
     const messages = await this.readMessages(resolved.id);
 
+    // Filter to assistant messages first, then take only the last N
+    // before reading parts — avoids O(M*P) file reads for long sessions
+    const assistantMsgs = messages.filter((m) => m.role === "assistant");
+    const recentMsgs = assistantMsgs.slice(-lines);
+
     const assistantMessages: string[] = [];
-    for (const msg of messages) {
-      if (msg.role === "assistant") {
-        // Read message content parts
-        const text = await this.readMessageParts(msg.id);
-        if (text) {
-          assistantMessages.push(text);
-        } else if (msg.error?.data?.message) {
-          assistantMessages.push(`[error] ${msg.error.data.message}`);
-        }
+    for (const msg of recentMsgs) {
+      const text = await this.readMessageParts(msg.id);
+      if (text) {
+        assistantMessages.push(text);
+      } else if (msg.error?.data?.message) {
+        assistantMessages.push(`[error] ${msg.error.data.message}`);
       }
     }
 
-    // Take last N messages
-    const recent = assistantMessages.slice(-lines);
-    return recent.join("\n---\n");
+    return assistantMessages.join("\n---\n");
   }
 
   async status(sessionId: string): Promise<AgentSession> {
-    const runningPids = await this.getPids();
     const resolved = await this.resolveSessionId(sessionId);
     if (!resolved) throw new Error(`Session not found: ${sessionId}`);
 
-    return this.buildSession(resolved, runningPids);
+    // Lightweight status: avoid expensive getOpenCodePids() (ps aux + lsof per process).
+    // Instead, check persisted metadata PID and recent-update heuristic.
+    const isRunning = await this.isSessionRunningLightweight(resolved);
+    const { model, tokens, cost } = await this.aggregateMessageStats(
+      resolved.id,
+    );
+
+    const createdAt = resolved.time?.created
+      ? new Date(resolved.time.created)
+      : new Date();
+    const updatedAt = resolved.time?.updated
+      ? new Date(resolved.time.updated)
+      : undefined;
+
+    let pid: number | undefined;
+    if (isRunning) {
+      const meta = await this.readSessionMeta(resolved.id);
+      if (meta?.pid && this.isProcessAlive(meta.pid)) {
+        pid = meta.pid;
+      }
+    }
+
+    return {
+      id: resolved.id,
+      adapter: this.id,
+      status: isRunning ? "running" : "stopped",
+      startedAt: createdAt,
+      stoppedAt: isRunning ? undefined : updatedAt,
+      cwd: resolved.directory,
+      model,
+      prompt: resolved.title?.slice(0, 200),
+      tokens,
+      cost,
+      pid,
+      meta: {
+        projectID: resolved.projectID,
+        slug: resolved.slug,
+        summary: resolved.summary,
+        version: resolved.version,
+      },
+    };
   }
 
   async launch(opts: LaunchOpts): Promise<AgentSession> {
@@ -643,6 +682,31 @@ export class OpenCodeAdapter implements AgentAdapter {
             return true;
           }
         }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Lightweight aliveness check for single-session queries (status/peek).
+   * Avoids the expensive getOpenCodePids() call (ps aux + lsof per process)
+   * by using persisted metadata and recency heuristics.
+   */
+  private async isSessionRunningLightweight(
+    sessionData: OpenCodeSessionFile,
+  ): Promise<boolean> {
+    // 1. Check persisted session metadata (for sessions launched via agentctl)
+    const meta = await this.readSessionMeta(sessionData.id);
+    if (meta?.pid && this.isProcessAlive(meta.pid)) {
+      return true;
+    }
+
+    // 2. Heuristic: session updated very recently → likely still running
+    if (sessionData.time?.updated) {
+      const updatedMs = new Date(sessionData.time.updated).getTime();
+      if (!Number.isNaN(updatedMs) && Date.now() - updatedMs < 60_000) {
+        return true;
       }
     }
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -519,7 +519,7 @@ function createRequestHandler(ctx: HandlerContext) {
       }
 
       case "session.peek": {
-        // Auto-detect adapter from tracked session, fall back to param or claude-code
+        // Auto-detect adapter from tracked session
         let tracked = ctx.sessionTracker.getSession(params.id as string);
         let peekId = tracked?.id || (params.id as string);
 
@@ -533,13 +533,28 @@ function createRequestHandler(ctx: HandlerContext) {
           }
         }
 
-        const adapterName =
-          (params.adapter as string) || tracked?.adapter || "claude-code";
-        const adapter = ctx.adapters[adapterName];
-        if (!adapter) throw new Error(`Unknown adapter: ${adapterName}`);
-        return adapter.peek(peekId, {
-          lines: params.lines as number | undefined,
-        });
+        const adapterName = (params.adapter as string) || tracked?.adapter;
+
+        // If we know the adapter, use it directly
+        if (adapterName) {
+          const adapter = ctx.adapters[adapterName];
+          if (!adapter) throw new Error(`Unknown adapter: ${adapterName}`);
+          return adapter.peek(peekId, {
+            lines: params.lines as number | undefined,
+          });
+        }
+
+        // No tracked adapter — try all adapters (don't assume claude-code)
+        for (const [, adapter] of Object.entries(ctx.adapters)) {
+          try {
+            return await adapter.peek(peekId, {
+              lines: params.lines as number | undefined,
+            });
+          } catch {
+            // Try next adapter
+          }
+        }
+        throw new Error(`Session not found: ${peekId}`);
       }
 
       case "session.launch": {


### PR DESCRIPTION
## Summary
- **peek()**: Only reads message parts for the last N assistant messages instead of all messages — avoids O(M*P) file reads for long sessions
- **status()**: Uses lightweight PID check (persisted metadata + recency heuristic) instead of expensive `getOpenCodePids()` which runs `ps aux` + `lsof` per process
- **Daemon routing**: `session.peek` now tries all adapters when session isn't tracked, instead of defaulting to `claude-code`

Fixes #97

## Test plan
- [x] Existing 55 opencode adapter tests pass
- [x] New test: peek only reads parts for last N messages (50 messages, lines=3)
- [x] New test: status detects running session via persisted metadata without calling getPids
- [x] New test: status detects running session via recent update heuristic
- [x] Full suite: 449 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)