### PR TITLE
fix: use temp file for large prompts instead of CLI args

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -17,6 +17,12 @@ import type {
 } from "../core/types.js";
 import { buildSpawnEnv } from "../utils/daemon-env.js";
 import { readHead, readTail } from "../utils/partial-read.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
 import { resolveBinaryPath } from "../utils/resolve-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -451,7 +457,18 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       args.push("--model", opts.model);
     }
 
-    args.push("-p", opts.prompt);
+    // For large prompts, pipe via stdin instead of CLI args to avoid
+    // OS argv size limits (ARG_MAX). Claude reads from stdin when -p is absent.
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    } else {
+      args.push("-p", opts.prompt);
+    }
 
     const env = buildSpawnEnv(undefined, opts.env);
     const cwd = opts.cwd || process.cwd();
@@ -467,7 +484,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     const child = spawn(claudePath, args, {
       cwd,
       env,
-      stdio: ["ignore", logFd.fd, logFd.fd],
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, logFd.fd],
       detached: true,
     });
 
@@ -483,8 +500,10 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     const pid = child.pid;
     const now = new Date();
 
-    // Close our handle — child keeps its own fd open
+    // Close our handles — child keeps its own fds open
     await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
 
     // Try to extract the real Claude Code session ID from the log output.
     // Claude Code's stream-json format emits a line with sessionId early on.

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -16,6 +16,12 @@ import type {
   StopOpts,
 } from "../core/types.js";
 import { buildSpawnEnv } from "../utils/daemon-env.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
 import { resolveBinaryPath } from "../utils/resolve-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -252,7 +258,19 @@ export class CodexAdapter implements AgentAdapter {
 
     const cwd = opts.cwd || process.cwd();
     args.push("--cd", cwd);
-    args.push(opts.prompt);
+
+    // For large prompts, pipe via stdin instead of CLI args to avoid
+    // OS argv size limits (ARG_MAX).
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    } else {
+      args.push(opts.prompt);
+    }
 
     const env = buildSpawnEnv(undefined, opts.env);
 
@@ -264,7 +282,7 @@ export class CodexAdapter implements AgentAdapter {
     const child = spawn(codexPath, args, {
       cwd,
       env,
-      stdio: ["ignore", logFd.fd, "ignore"],
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, "ignore"],
       detached: true,
     });
 
@@ -278,6 +296,8 @@ export class CodexAdapter implements AgentAdapter {
     const now = new Date();
 
     await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
 
     // Poll for thread_id from JSONL output
     let resolvedSessionId: string | undefined;

--- a/src/adapters/large-prompt-launch.test.ts
+++ b/src/adapters/large-prompt-launch.test.ts
@@ -1,0 +1,314 @@
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LARGE_PROMPT_THRESHOLD } from "../utils/prompt-file.js";
+
+// Track spawn calls including stdio configuration
+const spawnCalls: {
+  cmd: string;
+  args: string[];
+  opts: { stdio: unknown[] };
+}[] = [];
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...orig,
+    spawn: (
+      cmd: string,
+      args: string[],
+      opts: { stdio: unknown[]; [key: string]: unknown },
+    ) => {
+      spawnCalls.push({
+        cmd,
+        args: [...args],
+        opts: { stdio: [...opts.stdio] },
+      });
+      const child = new EventEmitter();
+      Object.assign(child, {
+        pid: 77777,
+        unref: () => {},
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+      });
+      return child;
+    },
+  };
+});
+
+vi.mock("../utils/resolve-binary.js", () => ({
+  resolveBinaryPath: async (name: string) => `/usr/local/bin/${name}`,
+}));
+
+// Import after mocks are declared (vitest hoists vi.mock)
+const { OpenCodeAdapter } = await import("./opencode.js");
+const { ClaudeCodeAdapter } = await import("./claude-code.js");
+const { CodexAdapter } = await import("./codex.js");
+const { PiAdapter } = await import("./pi.js");
+const { PiRustAdapter } = await import("./pi-rust.js");
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  spawnCalls.length = 0;
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentctl-large-prompt-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const smallPrompt = "Fix the bug";
+const largePrompt = "X".repeat(LARGE_PROMPT_THRESHOLD + 1);
+
+describe("Large prompt handling — OpenCode", () => {
+  let adapter: InstanceType<typeof OpenCodeAdapter>;
+
+  beforeEach(async () => {
+    const storageDir = path.join(tmpDir, "storage");
+    const sessionsMetaDir = path.join(tmpDir, "opencode-sessions");
+    await fs.mkdir(path.join(storageDir, "session"), { recursive: true });
+    await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+    adapter = new OpenCodeAdapter({
+      storageDir,
+      sessionsMetaDir,
+      getPids: async () => new Map(),
+      isProcessAlive: () => false,
+    });
+  });
+
+  it("passes small prompt as CLI arg", async () => {
+    await adapter.launch({
+      adapter: "opencode",
+      prompt: smallPrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args).toContain(smallPrompt);
+    // stdin should be "ignore" for small prompts
+    expect(spawnCalls[0].opts.stdio[0]).toBe("ignore");
+  });
+
+  it("pipes large prompt via stdin instead of CLI arg", async () => {
+    await adapter.launch({
+      adapter: "opencode",
+      prompt: largePrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    // Large prompt must NOT appear in args
+    expect(spawnCalls[0].args).not.toContain(largePrompt);
+    expect(spawnCalls[0].args).toEqual(["run"]);
+    // stdin should be a file descriptor (number), not "ignore"
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+});
+
+describe("Large prompt handling — Claude Code", () => {
+  let adapter: InstanceType<typeof ClaudeCodeAdapter>;
+
+  beforeEach(async () => {
+    const claudeDir = path.join(tmpDir, ".claude");
+    const sessionsMetaDir = path.join(claudeDir, "agentctl", "sessions");
+    await fs.mkdir(path.join(claudeDir, "projects"), { recursive: true });
+    await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+    adapter = new ClaudeCodeAdapter({
+      claudeDir,
+      sessionsMetaDir,
+      getPids: async () => new Map(),
+      isProcessAlive: () => false,
+    });
+  });
+
+  it("passes small prompt via -p flag", async () => {
+    await adapter.launch({
+      adapter: "claude-code",
+      prompt: smallPrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    expect(args).toContain("-p");
+    expect(args).toContain(smallPrompt);
+    expect(spawnCalls[0].opts.stdio[0]).toBe("ignore");
+  });
+
+  it("pipes large prompt via stdin, omits -p flag", async () => {
+    await adapter.launch({
+      adapter: "claude-code",
+      prompt: largePrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    // -p flag must NOT be present
+    expect(args).not.toContain("-p");
+    expect(args).not.toContain(largePrompt);
+    // stdin should be a file descriptor
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+});
+
+describe("Large prompt handling — Codex", () => {
+  let adapter: InstanceType<typeof CodexAdapter>;
+
+  beforeEach(async () => {
+    const codexDir = path.join(tmpDir, ".codex");
+    const sessionsMetaDir = path.join(codexDir, "agentctl", "sessions");
+    await fs.mkdir(path.join(codexDir, "sessions"), { recursive: true });
+    await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+    adapter = new CodexAdapter({
+      codexDir,
+      sessionsMetaDir,
+      getPids: async () => new Map(),
+      isProcessAlive: () => false,
+    });
+  });
+
+  it("passes small prompt as CLI arg", async () => {
+    await adapter.launch({
+      adapter: "codex",
+      prompt: smallPrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args).toContain(smallPrompt);
+    expect(spawnCalls[0].opts.stdio[0]).toBe("ignore");
+  });
+
+  it("pipes large prompt via stdin instead of CLI arg", async () => {
+    await adapter.launch({
+      adapter: "codex",
+      prompt: largePrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args).not.toContain(largePrompt);
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+});
+
+describe("Large prompt handling — Pi", () => {
+  let adapter: InstanceType<typeof PiAdapter>;
+
+  beforeEach(async () => {
+    const piDir = path.join(tmpDir, ".pi");
+    const sessionsMetaDir = path.join(piDir, "agentctl", "sessions");
+    await fs.mkdir(path.join(piDir, "agent", "sessions"), { recursive: true });
+    await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+    adapter = new PiAdapter({
+      piDir,
+      sessionsMetaDir,
+      getPids: async () => new Map(),
+      isProcessAlive: () => false,
+    });
+  });
+
+  it("passes small prompt via -p flag", async () => {
+    await adapter.launch({
+      adapter: "pi",
+      prompt: smallPrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    expect(args).toContain("-p");
+    expect(args).toContain(smallPrompt);
+    expect(spawnCalls[0].opts.stdio[0]).toBe("ignore");
+  });
+
+  it("pipes large prompt via stdin, omits -p flag", async () => {
+    await adapter.launch({
+      adapter: "pi",
+      prompt: largePrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    expect(args).not.toContain("-p");
+    expect(args).not.toContain(largePrompt);
+    // Should still have --mode json
+    expect(args).toContain("--mode");
+    expect(args).toContain("json");
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+});
+
+describe("Large prompt handling — Pi Rust", () => {
+  let adapter: InstanceType<typeof PiRustAdapter>;
+
+  beforeEach(async () => {
+    const sessionDir = path.join(tmpDir, "sessions");
+    const sessionsMetaDir = path.join(tmpDir, "agentctl-meta");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+    adapter = new PiRustAdapter({
+      sessionDir,
+      sessionsMetaDir,
+      getPids: async () => new Map(),
+      isProcessAlive: () => false,
+    });
+  });
+
+  it("passes small prompt as positional arg", async () => {
+    await adapter.launch({
+      adapter: "pi-rust",
+      prompt: smallPrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args).toContain(smallPrompt);
+    expect(spawnCalls[0].opts.stdio[0]).toBe("ignore");
+  });
+
+  it("pipes large prompt via stdin instead of positional arg", async () => {
+    await adapter.launch({
+      adapter: "pi-rust",
+      prompt: largePrompt,
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    expect(args).not.toContain(largePrompt);
+    // Should still have --print --mode json
+    expect(args).toContain("--print");
+    expect(args).toContain("--mode");
+    expect(args).toContain("json");
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+
+  it("preserves --model and --provider with large prompts", async () => {
+    await adapter.launch({
+      adapter: "pi-rust",
+      prompt: largePrompt,
+      model: "togetherai/meta-llama/Llama-3-70B",
+      cwd: tmpDir,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const args = spawnCalls[0].args;
+    expect(args).toContain("--provider");
+    expect(args).toContain("togetherai");
+    expect(args).toContain("--model");
+    expect(args).toContain("meta-llama/Llama-3-70B");
+    expect(args).not.toContain(largePrompt);
+    expect(typeof spawnCalls[0].opts.stdio[0]).toBe("number");
+  });
+});

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -16,6 +16,12 @@ import type {
   StopOpts,
 } from "../core/types.js";
 import { buildSpawnEnv } from "../utils/daemon-env.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
 import { resolveBinaryPath } from "../utils/resolve-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -301,7 +307,19 @@ export class OpenCodeAdapter implements AgentAdapter {
     if (opts.model) {
       args.push("--model", opts.model);
     }
-    args.push(opts.prompt);
+
+    // For large prompts, pipe via stdin instead of CLI args to avoid
+    // OS argv size limits (ARG_MAX).
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    } else {
+      args.push(opts.prompt);
+    }
 
     const env = buildSpawnEnv(undefined, opts.env);
     const cwd = opts.cwd || process.cwd();
@@ -317,7 +335,7 @@ export class OpenCodeAdapter implements AgentAdapter {
     const child = spawn(opencodePath, args, {
       cwd,
       env,
-      stdio: ["ignore", logFd.fd, logFd.fd],
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, logFd.fd],
       detached: true,
     });
 
@@ -330,8 +348,10 @@ export class OpenCodeAdapter implements AgentAdapter {
     const pid = child.pid;
     const now = new Date();
 
-    // Close our handle — child keeps its own fd open
+    // Close our handles — child keeps its own fds open
     await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
 
     // Generate a pending session ID — will be resolved when OpenCode creates the session file
     const sessionId = pid ? `pending-${pid}` : crypto.randomUUID();

--- a/src/adapters/pi-rust.ts
+++ b/src/adapters/pi-rust.ts
@@ -16,6 +16,12 @@ import type {
   StopOpts,
 } from "../core/types.js";
 import { buildSpawnEnv } from "../utils/daemon-env.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
 import { resolveBinaryPath } from "../utils/resolve-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -328,7 +334,20 @@ export class PiRustAdapter implements AgentAdapter {
   }
 
   async launch(opts: LaunchOpts): Promise<AgentSession> {
-    const args = ["--print", "--mode", "json", opts.prompt];
+    // For large prompts, pipe via stdin instead of CLI args to avoid
+    // OS argv size limits (ARG_MAX).
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    const args = useTempFile
+      ? ["--print", "--mode", "json"]
+      : ["--print", "--mode", "json", opts.prompt];
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    }
 
     if (opts.model) {
       const { provider, model } = parseProviderModel(
@@ -361,7 +380,7 @@ export class PiRustAdapter implements AgentAdapter {
     const child = spawn(piRustPath, args, {
       cwd,
       env,
-      stdio: ["ignore", logFd.fd, "ignore"],
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, "ignore"],
       detached: true,
     });
 
@@ -375,6 +394,8 @@ export class PiRustAdapter implements AgentAdapter {
     const now = new Date();
 
     await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
 
     // Try to extract the real session ID from the JSONL output
     let resolvedSessionId: string | undefined;

--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -16,6 +16,12 @@ import type {
   StopOpts,
 } from "../core/types.js";
 import { buildSpawnEnv } from "../utils/daemon-env.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
 import { resolveBinaryPath } from "../utils/resolve-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -323,7 +329,20 @@ export class PiAdapter implements AgentAdapter {
   }
 
   async launch(opts: LaunchOpts): Promise<AgentSession> {
-    const args = ["-p", opts.prompt, "--mode", "json"];
+    // For large prompts, pipe via stdin instead of CLI args to avoid
+    // OS argv size limits (ARG_MAX).
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    const args = useTempFile
+      ? ["--mode", "json"]
+      : ["-p", opts.prompt, "--mode", "json"];
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    }
 
     if (opts.model) {
       args.unshift("--model", opts.model);
@@ -341,7 +360,7 @@ export class PiAdapter implements AgentAdapter {
     const child = spawn(piPath, args, {
       cwd,
       env,
-      stdio: ["ignore", logFd.fd, logFd.fd],
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, logFd.fd],
       detached: true,
     });
 
@@ -355,8 +374,10 @@ export class PiAdapter implements AgentAdapter {
     const pid = child.pid;
     const now = new Date();
 
-    // Close our handle — child keeps its own fd open
+    // Close our handles — child keeps its own fds open
     await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
 
     // Try to extract the session ID from the JSON-mode stdout output.
     // Pi's first JSON line has type: "session" with an id field.

--- a/src/utils/prompt-file.test.ts
+++ b/src/utils/prompt-file.test.ts
@@ -1,0 +1,89 @@
+import * as fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  LARGE_PROMPT_THRESHOLD,
+  openPromptFd,
+  writePromptFile,
+} from "./prompt-file.js";
+
+describe("isLargePrompt", () => {
+  it("returns false for small prompts", () => {
+    expect(isLargePrompt("hello world")).toBe(false);
+  });
+
+  it("returns false for prompts just under threshold", () => {
+    const prompt = "x".repeat(LARGE_PROMPT_THRESHOLD - 1);
+    expect(isLargePrompt(prompt)).toBe(false);
+  });
+
+  it("returns true for prompts exceeding threshold", () => {
+    const prompt = "x".repeat(LARGE_PROMPT_THRESHOLD + 1);
+    expect(isLargePrompt(prompt)).toBe(true);
+  });
+
+  it("measures byte length not character length (multi-byte chars)", () => {
+    // Each emoji is 4 bytes in UTF-8
+    const charCount = Math.ceil(LARGE_PROMPT_THRESHOLD / 4) + 1;
+    const prompt = "\u{1F600}".repeat(charCount);
+    expect(prompt.length).toBeLessThan(LARGE_PROMPT_THRESHOLD);
+    expect(Buffer.byteLength(prompt)).toBeGreaterThan(LARGE_PROMPT_THRESHOLD);
+    expect(isLargePrompt(prompt)).toBe(true);
+  });
+});
+
+describe("writePromptFile / openPromptFd / cleanupPromptFile", () => {
+  let writtenPath: string;
+
+  afterEach(async () => {
+    if (writtenPath) {
+      await fs.unlink(writtenPath).catch(() => {});
+    }
+  });
+
+  it("writes prompt to a temp file and reads it back", async () => {
+    const prompt = "This is a test prompt with special chars: <>&\"'";
+    writtenPath = await writePromptFile(prompt);
+
+    expect(writtenPath).toContain("agentctl");
+    expect(writtenPath).toContain("prompt-");
+
+    const content = await fs.readFile(writtenPath, "utf-8");
+    expect(content).toBe(prompt);
+  });
+
+  it("writes large prompts correctly", async () => {
+    const prompt = "A".repeat(200_000);
+    writtenPath = await writePromptFile(prompt);
+
+    const content = await fs.readFile(writtenPath, "utf-8");
+    expect(content.length).toBe(200_000);
+  });
+
+  it("openPromptFd returns a valid file handle", async () => {
+    writtenPath = await writePromptFile("test content");
+    const fd = await openPromptFd(writtenPath);
+
+    expect(fd.fd).toBeGreaterThanOrEqual(0);
+    await fd.close();
+  });
+
+  it("cleanupPromptFile removes the file", async () => {
+    writtenPath = await writePromptFile("cleanup test");
+    await cleanupPromptFile(writtenPath);
+
+    const exists = await fs
+      .stat(writtenPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+    writtenPath = ""; // Already cleaned up
+  });
+
+  it("cleanupPromptFile is safe on missing files", async () => {
+    await expect(
+      cleanupPromptFile("/tmp/agentctl/nonexistent-file.txt"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/prompt-file.ts
+++ b/src/utils/prompt-file.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Byte-size threshold above which prompts are written to a temp file
+ * and piped via stdin instead of passed as CLI arguments.
+ *
+ * macOS ARG_MAX is ~1MB but includes all args + environment, and some
+ * tools/shells impose lower limits. 100KB is a safe threshold.
+ */
+export const LARGE_PROMPT_THRESHOLD = 100_000;
+
+/** Check if a prompt exceeds the safe CLI argument size threshold. */
+export function isLargePrompt(prompt: string): boolean {
+  return Buffer.byteLength(prompt) > LARGE_PROMPT_THRESHOLD;
+}
+
+/**
+ * Write a prompt to a temp file and return the path.
+ * The file is placed in `$TMPDIR/agentctl/` with a unique name.
+ */
+export async function writePromptFile(prompt: string): Promise<string> {
+  const tmpDir = path.join(os.tmpdir(), "agentctl");
+  await fs.mkdir(tmpDir, { recursive: true });
+  const filePath = path.join(tmpDir, `prompt-${Date.now()}-${process.pid}.txt`);
+  await fs.writeFile(filePath, prompt);
+  return filePath;
+}
+
+/**
+ * Open a prompt temp file as a read-only fd suitable for use as spawn stdio[0].
+ * Returns the fd handle — caller must close it after spawn.
+ */
+export async function openPromptFd(
+  promptFilePath: string,
+): Promise<fs.FileHandle> {
+  return fs.open(promptFilePath, "r");
+}
+
+/**
+ * Clean up a prompt temp file. Safe to call immediately after spawn since
+ * the child process inherits the fd directly (Unix: unlink removes the
+ * directory entry but data persists until all fds are closed).
+ */
+export async function cleanupPromptFile(filePath: string): Promise<void> {
+  await fs.unlink(filePath).catch(() => {});
+}


### PR DESCRIPTION
## Summary

- When combined `--spec`/`--file` content exceeds ~100KB, the prompt inlined into CLI arguments can hit OS argv limits (`ARG_MAX`), causing the child process to crash silently on launch
- For prompts exceeding the threshold, writes to a temp file and passes the file descriptor as `stdin` to the spawned process instead of including the prompt in the argument list
- Small prompts continue to use CLI args for backward compatibility
- All five adapters (claude-code, opencode, codex, pi, pi-rust) are updated with the same pattern

Fixes #98.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 466 tests pass
- [x] New unit tests for `isLargePrompt`, `writePromptFile`, `openPromptFd`, `cleanupPromptFile`
- [x] New integration tests verifying each adapter omits large prompts from CLI args and uses stdin fd instead
- [ ] Manual test: `agentctl launch opencode --spec <large-file> --file <file1> --file <file2>` with >100KB combined content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Charlie Hulcher <charlie@kindo.ai>