### PR TITLE
release: v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v1.6.0

### New Features
- **`--file` flag** for launch command (#95)

### Bug Fixes
- Insert `--` separator before positional prompt args in codex/opencode/pi-rust (#106)
- peek/status timeout on opencode sessions (#100)
- Use temp file for large prompts instead of CLI args (#101)

### Performance
- Use history.jsonl for Claude Code discover(), batch lsof calls (#96)

### Chore
- Add mandatory quality gate to AGENTS.md (#103)
- Reframe README around agent supervision (#102)

---
479/479 tests passing.