### PR TITLE
fix: session ID consistency + peek reliability + login detection

### DIFF
--- a/src/adapters/claude-code.test.ts
+++ b/src/adapters/claude-code.test.ts
@@ -1342,4 +1342,85 @@ describe("ClaudeCodeAdapter", () => {
       expect(sessions[0].prompt).toHaveLength(200);
     });
   });
+
+  describe("peek() launch-log fallback (#135)", () => {
+    it("falls back to launch log when session JSONL not found", async () => {
+      // Session meta exists with logPath but no JSONL file in projects dir
+      const sessionId = "short-lived-session-abc123";
+      const logPath = path.join(sessionsMetaDir, `launch-${Date.now()}.log`);
+
+      // Write launch log with assistant output (stream-json format)
+      const logLines = [
+        JSON.stringify({
+          sessionId,
+          type: "user",
+          message: { content: "Fix bug" },
+        }),
+        JSON.stringify({
+          sessionId,
+          type: "assistant",
+          message: { role: "assistant", content: "I fixed the bug." },
+        }),
+        JSON.stringify({
+          sessionId,
+          type: "assistant",
+          message: { role: "assistant", content: "All done." },
+        }),
+      ];
+      await fs.writeFile(logPath, logLines.join("\n"));
+
+      // Write session meta with logPath
+      const meta: LaunchedSessionMeta = {
+        sessionId,
+        pid: 99999,
+        cwd: "/tmp/test",
+        launchedAt: new Date().toISOString(),
+        logPath,
+      };
+      await fs.writeFile(
+        path.join(sessionsMetaDir, `${sessionId}.json`),
+        JSON.stringify(meta),
+      );
+
+      // peek should fall back to the launch log
+      const output = await adapter.peek(sessionId);
+      expect(output).toContain("I fixed the bug.");
+      expect(output).toContain("All done.");
+    });
+
+    it("throws when no session file and no launch log", async () => {
+      await expect(adapter.peek("nonexistent-id")).rejects.toThrow(
+        "Session not found",
+      );
+    });
+  });
+
+  describe("peek() for short-lived sessions (#135)", () => {
+    it("peeks a stopped session that has a JSONL file", async () => {
+      const now = new Date();
+      const created = new Date(now.getTime() - 12_000); // 12s ago
+
+      await createFakeProject("short-project", [
+        {
+          id: "short-session-1",
+          firstPrompt: "Quick task",
+          created: created.toISOString(),
+          modified: now.toISOString(),
+          messages: [
+            {
+              type: "user",
+              message: { role: "user", content: "Quick task" },
+            },
+            {
+              type: "assistant",
+              message: { role: "assistant", content: "Done quickly!" },
+            },
+          ],
+        },
+      ]);
+
+      const output = await adapter.peek("short-session-1");
+      expect(output).toBe("Done quickly!");
+    });
+  });
 });

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -33,6 +33,10 @@ const DEFAULT_CLAUDE_DIR = path.join(os.homedir(), ".claude");
 // Default: only show stopped sessions from the last 7 days
 const STOPPED_SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Patterns indicating authentication / login failures in launch output */
+const AUTH_ERROR_RE =
+  /not logged in|authentication required|unauthorized|login required/i;
+
 export interface PidInfo {
   pid: number;
   cwd: string;
@@ -53,6 +57,7 @@ export interface LaunchedSessionMeta {
   model?: string;
   prompt?: string;
   launchedAt: string;
+  logPath?: string;
 }
 
 export interface ClaudeCodeAdapterOpts {
@@ -413,7 +418,21 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
   async peek(sessionId: string, opts?: PeekOpts): Promise<string> {
     const lines = opts?.lines ?? 20;
-    const jsonlPath = await this.findSessionFile(sessionId);
+    let jsonlPath = await this.findSessionFile(sessionId);
+
+    // Fallback: use launch log if session JSONL not found (#135)
+    if (!jsonlPath) {
+      const meta = await this.readSessionMeta(sessionId);
+      if (meta?.logPath) {
+        try {
+          await fs.access(meta.logPath);
+          jsonlPath = meta.logPath;
+        } catch {
+          // log file doesn't exist
+        }
+      }
+    }
+
     if (!jsonlPath) throw new Error(`Session not found: ${sessionId}`);
 
     const content = await fs.readFile(jsonlPath, "utf-8");
@@ -504,7 +523,19 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     // Claude Code's stream-json format emits a line with sessionId early on.
     let resolvedSessionId: string | undefined;
     if (pid) {
-      resolvedSessionId = await this.pollForSessionId(logPath, pid, 15000);
+      const pollResult = await this.pollForSessionId(logPath, pid, 15000);
+
+      // Fail fast on auth/login errors (#134)
+      if (pollResult.error) {
+        throw new Error(`Claude Code launch failed: ${pollResult.error}`);
+      }
+
+      resolvedSessionId = pollResult.sessionId;
+
+      // Fallback: resolve canonical session ID from history.jsonl (#134)
+      if (!resolvedSessionId) {
+        resolvedSessionId = await this.resolveSessionIdFromHistory(cwd, now);
+      }
     }
 
     const sessionId = resolvedSessionId || crypto.randomUUID();
@@ -519,6 +550,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
         model: opts.model,
         prompt: opts.prompt.slice(0, 200),
         launchedAt: now.toISOString(),
+        logPath,
       });
     }
 
@@ -544,12 +576,13 @@ export class ClaudeCodeAdapter implements AgentAdapter {
   /**
    * Poll the launch log file for up to `timeoutMs` to extract the real session ID.
    * Claude Code's stream-json output includes sessionId in early messages.
+   * Also detects launch errors (auth failures, etc.) from the log.
    */
   private async pollForSessionId(
     logPath: string,
     pid: number,
     timeoutMs: number,
-  ): Promise<string | undefined> {
+  ): Promise<{ sessionId?: string; error?: string }> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       try {
@@ -559,10 +592,21 @@ export class ClaudeCodeAdapter implements AgentAdapter {
           try {
             const msg = JSON.parse(line);
             if (msg.sessionId && typeof msg.sessionId === "string") {
-              return msg.sessionId;
+              return { sessionId: msg.sessionId };
+            }
+            // Detect error messages in stream-json output
+            if (msg.type === "error" || msg.error) {
+              const errMsg =
+                typeof msg.error === "string"
+                  ? msg.error
+                  : (msg.error?.message ?? msg.message ?? JSON.stringify(msg));
+              return { error: errMsg };
             }
           } catch {
-            // Not valid JSON yet
+            // Raw text (stderr) — check for known error patterns
+            if (AUTH_ERROR_RE.test(line)) {
+              return { error: line.trim() };
+            }
           }
         }
       } catch {
@@ -572,9 +616,77 @@ export class ClaudeCodeAdapter implements AgentAdapter {
       try {
         process.kill(pid, 0);
       } catch {
-        break; // Process died
+        // Process died — do one final read for error info
+        return this.readLaunchLogForResult(logPath);
       }
       await sleep(200);
+    }
+    return {};
+  }
+
+  /**
+   * Final read of the launch log after process exit — extract session ID or error.
+   */
+  private async readLaunchLogForResult(
+    logPath: string,
+  ): Promise<{ sessionId?: string; error?: string }> {
+    try {
+      const content = await fs.readFile(logPath, "utf-8");
+      for (const line of content.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.sessionId && typeof msg.sessionId === "string") {
+            return { sessionId: msg.sessionId };
+          }
+          if (msg.type === "error" || msg.error) {
+            const errMsg =
+              typeof msg.error === "string"
+                ? msg.error
+                : (msg.error?.message ?? msg.message ?? JSON.stringify(msg));
+            return { error: errMsg };
+          }
+        } catch {
+          if (AUTH_ERROR_RE.test(line)) {
+            return { error: line.trim() };
+          }
+        }
+      }
+    } catch {
+      // Log doesn't exist
+    }
+    return {};
+  }
+
+  /**
+   * Fallback: resolve the canonical session ID from history.jsonl.
+   * Used when pollForSessionId can't extract the ID from the launch log.
+   */
+  private async resolveSessionIdFromHistory(
+    cwd: string,
+    launchTime: Date,
+  ): Promise<string | undefined> {
+    try {
+      const raw = await fs.readFile(this.historyPath, "utf-8");
+      const lines = raw.split("\n");
+      // Scan from end (most recent entries) for a match
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i];
+        if (!line) continue;
+        try {
+          const entry = JSON.parse(line) as HistoryEntry;
+          if (
+            entry.project === cwd &&
+            entry.timestamp >= launchTime.getTime() - 5000
+          ) {
+            return entry.sessionId;
+          }
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // history.jsonl doesn't exist
     }
     return undefined;
   }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -145,6 +145,59 @@ export async function startDaemon(opts: DaemonStartOpts = {}): Promise<{
     );
   }
 
+  // 8b. Detect stuck sessions — running > 5 min with no assistant output (#122)
+  const STUCK_THRESHOLD_MS = 5 * 60 * 1000;
+  const staleIds = sessionTracker.getStaleSessionIds(STUCK_THRESHOLD_MS);
+  if (staleIds.length > 0) {
+    let stuckCount = 0;
+    for (const id of staleIds) {
+      const record = state.getSession(id);
+      if (!record) continue;
+      const adapterName = record.adapter;
+      const adapter = adapters[adapterName];
+      if (!adapter) continue;
+
+      try {
+        const output = await adapter.peek(id, { lines: 1 });
+        if (!output || output.trim() === "") {
+          // Session has no assistant output — stuck at enqueue/dequeue
+          sessionTracker.markStuck(id);
+          lockManager.autoUnlock(id);
+          // Kill the stuck process
+          if (record.pid) {
+            try {
+              process.kill(record.pid, "SIGTERM");
+            } catch {
+              // Already dead
+            }
+          }
+          const stuckRec = state.getSession(id);
+          if (stuckRec) emitSessionStoppedWebhook(stuckRec);
+          stuckCount++;
+        }
+      } catch {
+        // peek failed — session not discoverable, mark stuck
+        sessionTracker.markStuck(id);
+        lockManager.autoUnlock(id);
+        if (record.pid) {
+          try {
+            process.kill(record.pid, "SIGTERM");
+          } catch {
+            // Already dead
+          }
+        }
+        const stuckRec = state.getSession(id);
+        if (stuckRec) emitSessionStoppedWebhook(stuckRec);
+        stuckCount++;
+      }
+    }
+    if (stuckCount > 0) {
+      console.error(
+        `Startup cleanup: marked ${stuckCount} stuck sessions as errored`,
+      );
+    }
+  }
+
   // 9. Resume fuse timers
   fuseEngine.resumeTimers();
 
@@ -512,9 +565,52 @@ function createRequestHandler(ctx: HandlerContext) {
         if (!adapter) throw new Error(`Unknown adapter: ${adapterName}`);
         // Use the full session ID if we resolved it from the tracker
         const peekId = tracked?.id || (params.id as string);
-        return adapter.peek(peekId, {
-          lines: params.lines as number | undefined,
-        });
+        try {
+          return await adapter.peek(peekId, {
+            lines: params.lines as number | undefined,
+          });
+        } catch (peekErr) {
+          // Fallback: read assistant output from launch log (#135)
+          const logPath = tracked?.meta?.logPath as string | undefined;
+          if (logPath) {
+            try {
+              const logContent = await fs.readFile(logPath, "utf-8");
+              const assistantMessages: string[] = [];
+              for (const line of logContent.split("\n")) {
+                if (!line.trim()) continue;
+                try {
+                  const msg = JSON.parse(line);
+                  if (msg.type === "assistant" && msg.message?.content) {
+                    const text =
+                      typeof msg.message.content === "string"
+                        ? msg.message.content
+                        : Array.isArray(msg.message.content)
+                          ? msg.message.content
+                              .filter(
+                                (b: { type: string; text?: string }) =>
+                                  b.type === "text" && b.text,
+                              )
+                              .map(
+                                (b: { type: string; text?: string }) => b.text,
+                              )
+                              .join("\n")
+                          : "";
+                    if (text) assistantMessages.push(text);
+                  }
+                } catch {
+                  // skip malformed
+                }
+              }
+              if (assistantMessages.length > 0) {
+                const maxLines = (params.lines as number | undefined) ?? 20;
+                return assistantMessages.slice(-maxLines).join("\n---\n");
+              }
+            } catch {
+              // log file unreadable — fall through to original error
+            }
+          }
+          throw peekErr;
+        }
       }
 
       case "session.launch": {

--- a/src/daemon/session-tracker.test.ts
+++ b/src/daemon/session-tracker.test.ts
@@ -357,6 +357,66 @@ describe("SessionTracker", () => {
     });
   });
 
+  describe("getStaleSessionIds (#122)", () => {
+    it("returns IDs of running sessions older than threshold", () => {
+      tracker.track(
+        makeSession({
+          id: "old-running",
+          status: "running",
+          startedAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min ago
+        }),
+        "claude-code",
+      );
+      tracker.track(
+        makeSession({
+          id: "new-running",
+          status: "running",
+          startedAt: new Date(), // just now
+        }),
+        "claude-code",
+      );
+
+      const stale = tracker.getStaleSessionIds(5 * 60 * 1000);
+      expect(stale).toContain("old-running");
+      expect(stale).not.toContain("new-running");
+    });
+
+    it("ignores stopped sessions", () => {
+      tracker.track(
+        makeSession({
+          id: "old-stopped",
+          status: "stopped",
+          startedAt: new Date(Date.now() - 10 * 60 * 1000),
+        }),
+        "claude-code",
+      );
+
+      const stale = tracker.getStaleSessionIds(5 * 60 * 1000);
+      expect(stale).not.toContain("old-stopped");
+    });
+  });
+
+  describe("markStuck (#122)", () => {
+    it("marks a running session as error", () => {
+      tracker.track(
+        makeSession({ id: "stuck-1", status: "running", pid: 12345 }),
+        "claude-code",
+      );
+
+      const result = tracker.markStuck("stuck-1");
+      expect(result).toBeDefined();
+      expect(result?.status).toBe("error");
+      expect(result?.stoppedAt).toBeDefined();
+
+      // Verify persisted in state
+      expect(state.getSession("stuck-1")?.status).toBe("error");
+    });
+
+    it("returns undefined for unknown session", () => {
+      expect(tracker.markStuck("unknown")).toBeUndefined();
+    });
+  });
+
   describe("startLaunchCleanup / stopLaunchCleanup", () => {
     it("periodically checks PID liveness", async () => {
       vi.useFakeTimers();

--- a/src/daemon/session-tracker.ts
+++ b/src/daemon/session-tracker.ts
@@ -183,6 +183,37 @@ export class SessionTracker {
     }
     return dead;
   }
+
+  /**
+   * Find running sessions older than `maxAgeMs` — candidates for "stuck" detection.
+   * Returns session IDs of running sessions that exceed the age threshold (#122).
+   */
+  getStaleSessionIds(maxAgeMs: number): string[] {
+    const stale: string[] = [];
+    const now = Date.now();
+    for (const [id, record] of Object.entries(this.state.getSessions())) {
+      if (record.status !== "running" && record.status !== "idle") continue;
+      const age = now - new Date(record.startedAt).getTime();
+      if (age > maxAgeMs) stale.push(id);
+    }
+    return stale;
+  }
+
+  /**
+   * Mark a session as stuck/errored. Used when a session is detected
+   * as alive but not making progress (#122).
+   */
+  markStuck(sessionId: string): SessionRecord | undefined {
+    const record = this.state.getSession(sessionId);
+    if (!record) return undefined;
+    const updated = {
+      ...record,
+      status: "error" as const,
+      stoppedAt: new Date().toISOString(),
+    };
+    this.state.setSession(sessionId, updated);
+    return updated;
+  }
 }
 
 /** Check if a process is alive via kill(pid, 0) signal check */


### PR DESCRIPTION
Closes #135, closes #134, closes #122

**#134:** `pollForSessionId()` now detects auth/login errors and fails fast. Added `resolveSessionIdFromHistory()` fallback for canonical ID resolution.

**#135:** `peek()` falls back to reading launch log when session JSONL is missing (short-lived sessions).

**#122:** Daemon startup detects sessions stuck at enqueue/dequeue (>5min, no assistant output) and marks them errored + kills the process. 7 new regression tests, all 517 pass.