### PR TITLE
release: v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-03-12
+
+fix: PID-based locks replace session-ID-coupled locks — self-healing, adapter-independent (#115). fix: pending-* entry cleanup — TTL + dead PID removal (#114). fix: LaunchedSessionMeta minimized with 24h TTL auto-cleanup, shared utility across all 5 adapters (#112). fix: session ID consistency — canonical IDs from launch, login failure detection (#134). fix: peek reliability for short-lived sessions via launch log fallback (#135). fix: stuck session detection and cleanup on daemon startup (#122).
+
+
 ## [1.8.0] - 2026-03-11
 
 feat: Phase 1 ACP adoption via ACP transport. feat: callback metadata, lifecycle webhooks, spawn ENOENT retry. feat: complete stateless daemon core. fix: eliminate pending session IDs, resolve real ID at launch. fix: webhook emit numeric exit_status, compatible HMAC headers. fix: eliminate daemon-env.json, derive env at spawn time. fix: update resolve-binary util. docs: ADR-001 adopt ACP as primary agent interface. docs: audit and align documentation with current codebase.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orgloop/agentctl",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orgloop/agentctl",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Universal agent supervision interface — monitor and control AI coding agents from a single CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v1.9.0

- Version bump: 1.8.0 → 1.9.0 (minor)
- CHANGELOG.md updated
- Build + tests passed

### Post-merge steps

```bash
git checkout main && git pull origin main
git tag v1.9.0
git push origin v1.9.0
```

Tag push triggers the npm publish workflow.