### PR TITLE
feat: add Slate harness

### DIFF
--- a/src/adapters/slate.test.ts
+++ b/src/adapters/slate.test.ts
@@ -1,0 +1,398 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type PidInfo, SlateAdapter } from "./slate.js";
+
+let tmpDir: string;
+let slateDir: string;
+let sessionsMetaDir: string;
+let adapter: SlateAdapter;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentctl-slate-test-"));
+  slateDir = path.join(tmpDir, ".slate");
+  sessionsMetaDir = path.join(slateDir, "agentctl", "sessions");
+  await fs.mkdir(sessionsMetaDir, { recursive: true });
+
+  adapter = new SlateAdapter({
+    slateDir,
+    sessionsMetaDir,
+    getPids: async () => new Map(),
+    isProcessAlive: () => false,
+  });
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// --- Helper to create fake session metadata + log ---
+
+interface FakeSessionOpts {
+  sessionId: string;
+  pid?: number;
+  logContent?: string;
+  launchedAt?: string;
+  startTime?: string;
+}
+
+async function createFakeSession(opts: FakeSessionOpts) {
+  const logPath = path.join(sessionsMetaDir, `launch-${Date.now()}.log`);
+  if (opts.logContent) {
+    await fs.writeFile(logPath, opts.logContent);
+  }
+
+  const meta = {
+    sessionId: opts.sessionId,
+    pid: opts.pid || 12345,
+    startTime: opts.startTime || "Thu Mar 12 10:00:00 2026",
+    launchedAt: opts.launchedAt || new Date().toISOString(),
+    logPath,
+  };
+
+  await fs.writeFile(
+    path.join(sessionsMetaDir, `${opts.sessionId}.json`),
+    JSON.stringify(meta, null, 2),
+  );
+
+  return { logPath, meta };
+}
+
+/** Build a Claude Code SDK-compatible JSONL log */
+function buildStreamJsonLog(messages: Array<Record<string, unknown>>): string {
+  return messages.map((m) => JSON.stringify(m)).join("\n");
+}
+
+// --- Tests ---
+
+describe("SlateAdapter", () => {
+  it("has correct id", () => {
+    expect(adapter.id).toBe("slate");
+  });
+
+  describe("discover()", () => {
+    it("returns empty array when no sessions exist", async () => {
+      const sessions = await adapter.discover();
+      expect(sessions).toEqual([]);
+    });
+
+    it("discovers stopped sessions from metadata", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "user",
+          sessionId: "sess-1",
+          cwd: "/tmp/project",
+          message: { role: "user", content: "hello world" },
+        },
+        {
+          type: "assistant",
+          sessionId: "sess-1",
+          message: {
+            role: "assistant",
+            content: "Hi there!",
+            model: "claude-sonnet-4-5-20250929",
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-1", logContent: log });
+
+      const sessions = await adapter.discover();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].id).toBe("sess-1");
+      expect(sessions[0].status).toBe("stopped");
+      expect(sessions[0].adapter).toBe("slate");
+      expect(sessions[0].cwd).toBe("/tmp/project");
+      expect(sessions[0].model).toBe("claude-sonnet-4-5-20250929");
+      expect(sessions[0].tokens).toEqual({ in: 100, out: 50 });
+    });
+
+    it("detects running sessions when PID is alive", async () => {
+      const aliveAdapter = new SlateAdapter({
+        slateDir,
+        sessionsMetaDir,
+        getPids: async () => new Map(),
+        isProcessAlive: (pid) => pid === 42,
+      });
+
+      await createFakeSession({ sessionId: "sess-alive", pid: 42 });
+
+      const sessions = await aliveAdapter.discover();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].status).toBe("running");
+      expect(sessions[0].pid).toBe(42);
+    });
+  });
+
+  describe("isAlive()", () => {
+    it("returns false for unknown session", async () => {
+      expect(await adapter.isAlive("nonexistent")).toBe(false);
+    });
+
+    it("returns false when PID is dead", async () => {
+      await createFakeSession({ sessionId: "sess-dead", pid: 99999 });
+      expect(await adapter.isAlive("sess-dead")).toBe(false);
+    });
+
+    it("returns true when PID is alive", async () => {
+      const aliveAdapter = new SlateAdapter({
+        slateDir,
+        sessionsMetaDir,
+        getPids: async () => new Map(),
+        isProcessAlive: (pid) => pid === 55,
+      });
+
+      await createFakeSession({ sessionId: "sess-55", pid: 55 });
+      expect(await aliveAdapter.isAlive("sess-55")).toBe(true);
+    });
+
+    it("detects PID recycling via start time mismatch", async () => {
+      const recycledPids = new Map<number, PidInfo>([
+        [
+          55,
+          {
+            pid: 55,
+            cwd: "/tmp",
+            args: "slate -q",
+            startTime: "Fri Mar 13 10:00:00 2026", // different from recorded
+          },
+        ],
+      ]);
+
+      const recycleAdapter = new SlateAdapter({
+        slateDir,
+        sessionsMetaDir,
+        getPids: async () => recycledPids,
+        isProcessAlive: () => true,
+      });
+
+      await createFakeSession({
+        sessionId: "sess-recycled",
+        pid: 55,
+        startTime: "Thu Mar 12 10:00:00 2026",
+      });
+
+      expect(await recycleAdapter.isAlive("sess-recycled")).toBe(false);
+    });
+  });
+
+  describe("list()", () => {
+    it("returns empty array when no sessions exist", async () => {
+      const sessions = await adapter.list({ all: true });
+      expect(sessions).toEqual([]);
+    });
+
+    it("filters by status", async () => {
+      await createFakeSession({ sessionId: "sess-1" });
+
+      const running = await adapter.list({ status: "running" });
+      expect(running).toEqual([]);
+
+      const stopped = await adapter.list({ status: "stopped", all: true });
+      expect(stopped).toHaveLength(1);
+    });
+
+    it("hides stopped sessions by default", async () => {
+      await createFakeSession({ sessionId: "sess-stopped" });
+
+      const sessions = await adapter.list();
+      expect(sessions).toEqual([]);
+    });
+
+    it("shows stopped sessions with --all", async () => {
+      await createFakeSession({ sessionId: "sess-stopped" });
+
+      const sessions = await adapter.list({ all: true });
+      expect(sessions).toHaveLength(1);
+    });
+  });
+
+  describe("peek()", () => {
+    it("returns assistant messages from JSONL log", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "user",
+          sessionId: "sess-peek",
+          message: { role: "user", content: "what is 2+2?" },
+        },
+        {
+          type: "assistant",
+          sessionId: "sess-peek",
+          message: { role: "assistant", content: "The answer is 4." },
+        },
+        {
+          type: "assistant",
+          sessionId: "sess-peek",
+          message: { role: "assistant", content: "Anything else?" },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-peek", logContent: log });
+
+      const output = await adapter.peek("sess-peek");
+      expect(output).toContain("The answer is 4.");
+      expect(output).toContain("Anything else?");
+    });
+
+    it("respects line limit", async () => {
+      const messages = [];
+      for (let i = 0; i < 10; i++) {
+        messages.push({
+          type: "assistant",
+          sessionId: "sess-limit",
+          message: { role: "assistant", content: `Message ${i}` },
+        });
+      }
+      const log = buildStreamJsonLog(messages);
+
+      await createFakeSession({ sessionId: "sess-limit", logContent: log });
+
+      const output = await adapter.peek("sess-limit", { lines: 3 });
+      expect(output).toContain("Message 7");
+      expect(output).toContain("Message 8");
+      expect(output).toContain("Message 9");
+      expect(output).not.toContain("Message 6");
+    });
+
+    it("handles array content blocks", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "assistant",
+          sessionId: "sess-blocks",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "First block" },
+              { type: "text", text: "Second block" },
+            ],
+          },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-blocks", logContent: log });
+
+      const output = await adapter.peek("sess-blocks");
+      expect(output).toContain("First block");
+      expect(output).toContain("Second block");
+    });
+
+    it("throws for unknown session", async () => {
+      await expect(adapter.peek("nonexistent")).rejects.toThrow(
+        "Session not found",
+      );
+    });
+  });
+
+  describe("status()", () => {
+    it("returns session details", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "assistant",
+          sessionId: "sess-status",
+          cwd: "/tmp/project",
+          message: {
+            role: "assistant",
+            content: "Hello",
+            model: "claude-sonnet-4-5-20250929",
+            usage: { input_tokens: 200, output_tokens: 100 },
+          },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-status", logContent: log });
+
+      const session = await adapter.status("sess-status");
+      expect(session.id).toBe("sess-status");
+      expect(session.adapter).toBe("slate");
+      expect(session.status).toBe("stopped");
+      expect(session.model).toBe("claude-sonnet-4-5-20250929");
+      expect(session.tokens).toEqual({ in: 200, out: 100 });
+    });
+
+    it("throws for unknown session", async () => {
+      await expect(adapter.status("nonexistent")).rejects.toThrow(
+        "Session not found",
+      );
+    });
+  });
+
+  describe("stop()", () => {
+    it("throws when no PID found", async () => {
+      await expect(adapter.stop("nonexistent")).rejects.toThrow(
+        "No running process",
+      );
+    });
+  });
+
+  describe("stream-json parsing", () => {
+    it("aggregates tokens across multiple assistant messages", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "assistant",
+          sessionId: "sess-tokens",
+          message: {
+            role: "assistant",
+            content: "First response",
+            usage: { input_tokens: 100, output_tokens: 50 },
+          },
+        },
+        {
+          type: "assistant",
+          sessionId: "sess-tokens",
+          message: {
+            role: "assistant",
+            content: "Second response",
+            usage: { input_tokens: 200, output_tokens: 100 },
+          },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-tokens", logContent: log });
+
+      const session = await adapter.status("sess-tokens");
+      expect(session.tokens).toEqual({ in: 300, out: 150 });
+    });
+
+    it("extracts first user prompt", async () => {
+      const log = buildStreamJsonLog([
+        {
+          type: "user",
+          sessionId: "sess-prompt",
+          message: { role: "user", content: "Build me a web app" },
+        },
+        {
+          type: "assistant",
+          sessionId: "sess-prompt",
+          message: { role: "assistant", content: "Sure!" },
+        },
+      ]);
+
+      await createFakeSession({ sessionId: "sess-prompt", logContent: log });
+
+      const session = await adapter.status("sess-prompt");
+      expect(session.prompt).toBe("Build me a web app");
+    });
+
+    it("skips malformed JSONL lines gracefully", async () => {
+      const log = [
+        "not valid json",
+        JSON.stringify({
+          type: "assistant",
+          sessionId: "sess-malformed",
+          message: { role: "assistant", content: "Valid message" },
+        }),
+        "{broken json",
+      ].join("\n");
+
+      await createFakeSession({
+        sessionId: "sess-malformed",
+        logContent: log,
+      });
+
+      const output = await adapter.peek("sess-malformed");
+      expect(output).toBe("Valid message");
+    });
+  });
+});

--- a/src/adapters/slate.ts
+++ b/src/adapters/slate.ts
@@ -1,0 +1,725 @@
+import { execFile, spawn } from "node:child_process";
+import crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import type {
+  AgentAdapter,
+  AgentSession,
+  DiscoveredSession,
+  LaunchOpts,
+  LifecycleEvent,
+  ListOpts,
+  PeekOpts,
+  StopOpts,
+} from "../core/types.js";
+import { buildSpawnEnv } from "../utils/daemon-env.js";
+import {
+  cleanupPromptFile,
+  isLargePrompt,
+  openPromptFd,
+  writePromptFile,
+} from "../utils/prompt-file.js";
+import { resolveBinaryPath } from "../utils/resolve-binary.js";
+import {
+  cleanupExpiredMeta,
+  readSessionMeta,
+  writeSessionMeta,
+} from "../utils/session-meta.js";
+import { spawnWithRetry } from "../utils/spawn-with-retry.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_SLATE_DIR = path.join(os.homedir(), ".slate");
+
+const STOPPED_SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface PidInfo {
+  pid: number;
+  cwd: string;
+  args: string;
+  startTime?: string;
+}
+
+export interface SlateAdapterOpts {
+  slateDir?: string;
+  sessionsMetaDir?: string;
+  getPids?: () => Promise<Map<number, PidInfo>>;
+  isProcessAlive?: (pid: number) => boolean;
+}
+
+/**
+ * Slate streams Claude Code SDK-compatible JSONL via --output-format stream-json.
+ * We reuse the same message types.
+ */
+interface JSONLMessage {
+  type: "user" | "assistant" | "error" | string;
+  sessionId?: string;
+  timestamp?: string;
+  cwd?: string;
+  version?: string;
+  message?: {
+    role?: string;
+    content?: string | Array<{ type: string; text?: string }>;
+    model?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+  error?: string | { message?: string };
+}
+
+/**
+ * Slate adapter — launches Slate with --output-format stream-json and
+ * tracks sessions via PID + launch-log files.
+ *
+ * Slate's stream-json output is compatible with the Claude Code SDK,
+ * so we reuse the same JSONL parsing approach.
+ */
+export class SlateAdapter implements AgentAdapter {
+  readonly id = "slate";
+  private readonly slateDir: string;
+  private readonly sessionsMetaDir: string;
+  private readonly getPids: () => Promise<Map<number, PidInfo>>;
+  private readonly isProcessAlive: (pid: number) => boolean;
+
+  constructor(opts?: SlateAdapterOpts) {
+    this.slateDir = opts?.slateDir || DEFAULT_SLATE_DIR;
+    this.sessionsMetaDir =
+      opts?.sessionsMetaDir || path.join(this.slateDir, "agentctl", "sessions");
+    this.getPids = opts?.getPids || getSlatePids;
+    this.isProcessAlive = opts?.isProcessAlive || defaultIsProcessAlive;
+  }
+
+  async discover(): Promise<DiscoveredSession[]> {
+    cleanupExpiredMeta(this.sessionsMetaDir).catch(() => {});
+
+    const results: DiscoveredSession[] = [];
+    const runningPids = await this.getPids();
+
+    // Discover from persisted session metadata (launched via agentctl)
+    try {
+      const files = await fs.readdir(this.sessionsMetaDir);
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue;
+        try {
+          const raw = await fs.readFile(
+            path.join(this.sessionsMetaDir, file),
+            "utf-8",
+          );
+          const meta = JSON.parse(raw);
+          if (!meta.sessionId) continue;
+
+          const isRunning = meta.pid
+            ? this.isPidAlive(meta.pid, meta.startTime, runningPids)
+            : false;
+
+          const logData = meta.logPath
+            ? await this.parseLogFile(meta.logPath)
+            : undefined;
+
+          results.push({
+            id: meta.sessionId,
+            status: isRunning ? "running" : "stopped",
+            adapter: this.id,
+            cwd: logData?.cwd,
+            model: logData?.model,
+            startedAt: meta.launchedAt ? new Date(meta.launchedAt) : undefined,
+            stoppedAt: isRunning ? undefined : new Date(),
+            pid: isRunning ? meta.pid : undefined,
+            prompt: logData?.prompt?.slice(0, 200),
+            tokens: logData?.tokens,
+            cost: logData?.cost,
+          });
+        } catch {
+          // skip unreadable files
+        }
+      }
+    } catch {
+      // sessionsMetaDir doesn't exist yet
+    }
+
+    return results;
+  }
+
+  async isAlive(sessionId: string): Promise<boolean> {
+    const meta = await readSessionMeta(this.sessionsMetaDir, sessionId);
+    if (!meta?.pid) return false;
+
+    const runningPids = await this.getPids();
+    return this.isPidAlive(meta.pid, meta.startTime, runningPids);
+  }
+
+  async list(opts?: ListOpts): Promise<AgentSession[]> {
+    const discovered = await this.discover();
+    const sessions: AgentSession[] = [];
+
+    for (const disc of discovered) {
+      const session: AgentSession = {
+        id: disc.id,
+        adapter: this.id,
+        status: disc.status === "running" ? "running" : "stopped",
+        startedAt: disc.startedAt || new Date(),
+        stoppedAt: disc.stoppedAt,
+        cwd: disc.cwd,
+        model: disc.model,
+        prompt: disc.prompt,
+        tokens: disc.tokens,
+        cost: disc.cost,
+        pid: disc.pid,
+        meta: {},
+      };
+
+      if (opts?.status && session.status !== opts.status) continue;
+
+      if (!opts?.all && session.status === "stopped") {
+        const age = Date.now() - session.startedAt.getTime();
+        if (age > STOPPED_SESSION_MAX_AGE_MS) continue;
+      }
+
+      if (
+        !opts?.all &&
+        !opts?.status &&
+        session.status !== "running" &&
+        session.status !== "idle"
+      ) {
+        continue;
+      }
+
+      sessions.push(session);
+    }
+
+    sessions.sort((a, b) => {
+      if (a.status === "running" && b.status !== "running") return -1;
+      if (b.status === "running" && a.status !== "running") return 1;
+      return b.startedAt.getTime() - a.startedAt.getTime();
+    });
+
+    return sessions;
+  }
+
+  async peek(sessionId: string, opts?: PeekOpts): Promise<string> {
+    const lines = opts?.lines ?? 20;
+
+    // Find the log file for this session
+    const logPath = await this.getLogPathForSession(sessionId);
+    if (!logPath) throw new Error(`Session not found: ${sessionId}`);
+
+    const content = await fs.readFile(logPath, "utf-8");
+    const jsonlLines = content.trim().split("\n");
+
+    const assistantMessages: string[] = [];
+    for (const line of jsonlLines) {
+      try {
+        const msg = JSON.parse(line) as JSONLMessage;
+        if (msg.type === "assistant" && msg.message?.content) {
+          const text = extractTextContent(msg.message.content);
+          if (text) assistantMessages.push(text);
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+
+    const recent = assistantMessages.slice(-lines);
+    return recent.join("\n---\n");
+  }
+
+  async status(sessionId: string): Promise<AgentSession> {
+    const meta = await readSessionMeta(this.sessionsMetaDir, sessionId);
+    if (!meta) throw new Error(`Session not found: ${sessionId}`);
+
+    const runningPids = await this.getPids();
+    const isRunning = meta.pid
+      ? this.isPidAlive(meta.pid, meta.startTime, runningPids)
+      : false;
+
+    const logData = meta.logPath
+      ? await this.parseLogFile(meta.logPath)
+      : undefined;
+
+    return {
+      id: meta.sessionId,
+      adapter: this.id,
+      status: isRunning ? "running" : "stopped",
+      startedAt: meta.launchedAt ? new Date(meta.launchedAt) : new Date(),
+      stoppedAt: isRunning ? undefined : new Date(),
+      cwd: logData?.cwd,
+      model: logData?.model,
+      prompt: logData?.prompt?.slice(0, 200),
+      tokens: logData?.tokens,
+      cost: logData?.cost,
+      pid: isRunning ? meta.pid : undefined,
+      meta: { logPath: meta.logPath },
+    };
+  }
+
+  async launch(opts: LaunchOpts): Promise<AgentSession> {
+    const args = [
+      "-q",
+      "--output-format",
+      "stream-json",
+      "--dangerously-set-permissions",
+    ];
+
+    if (opts.cwd) {
+      args.push("--workspace", opts.cwd);
+    }
+
+    if (opts.model) {
+      args.push("--model", opts.model);
+    }
+
+    const useTempFile = isLargePrompt(opts.prompt);
+    let promptFilePath: string | undefined;
+    let promptFd: Awaited<ReturnType<typeof openPromptFd>> | undefined;
+
+    if (useTempFile) {
+      promptFilePath = await writePromptFile(opts.prompt);
+      promptFd = await openPromptFd(promptFilePath);
+    } else {
+      args.push("-p", opts.prompt);
+    }
+
+    const cwd = opts.cwd || process.cwd();
+    const env = buildSpawnEnv(opts.env);
+
+    // Write stdout to a log file for session ID extraction and peek
+    await fs.mkdir(this.sessionsMetaDir, { recursive: true });
+    const logPath = path.join(this.sessionsMetaDir, `launch-${Date.now()}.log`);
+    const logFd = await fs.open(logPath, "w");
+
+    const child = await spawnWithRetry("slate", args, {
+      cwd,
+      env,
+      stdio: [promptFd ? promptFd.fd : "ignore", logFd.fd, logFd.fd],
+      detached: true,
+    });
+
+    child.unref();
+
+    const pid = child.pid;
+    const now = new Date();
+
+    await logFd.close();
+    if (promptFd) await promptFd.close();
+    if (promptFilePath) await cleanupPromptFile(promptFilePath);
+
+    // Poll for session ID from stream-json output
+    let resolvedSessionId: string | undefined;
+    if (pid) {
+      const pollResult = await this.pollForSessionId(logPath, pid, 15000);
+      if (pollResult.error) {
+        throw new Error(`Slate launch failed: ${pollResult.error}`);
+      }
+      resolvedSessionId = pollResult.sessionId;
+    }
+
+    const sessionId = resolvedSessionId || crypto.randomUUID();
+
+    if (pid) {
+      await writeSessionMeta(this.sessionsMetaDir, { sessionId, pid });
+      // Also store logPath in the meta file for peek fallback
+      const metaPath = path.join(this.sessionsMetaDir, `${sessionId}.json`);
+      try {
+        const raw = await fs.readFile(metaPath, "utf-8");
+        const meta = JSON.parse(raw);
+        meta.logPath = logPath;
+        await fs.writeFile(metaPath, JSON.stringify(meta, null, 2));
+      } catch {
+        // meta write failed — non-fatal
+      }
+    }
+
+    return {
+      id: sessionId,
+      adapter: this.id,
+      status: "running",
+      startedAt: now,
+      cwd,
+      model: opts.model,
+      prompt: opts.prompt.slice(0, 200),
+      pid,
+      meta: {
+        adapterOpts: opts.adapterOpts,
+        spec: opts.spec,
+        logPath,
+      },
+    };
+  }
+
+  async stop(sessionId: string, opts?: StopOpts): Promise<void> {
+    const meta = await readSessionMeta(this.sessionsMetaDir, sessionId);
+    const pid = meta?.pid;
+    if (!pid) throw new Error(`No running process for session: ${sessionId}`);
+
+    if (opts?.force) {
+      process.kill(pid, "SIGINT");
+      await sleep(5000);
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already dead
+      }
+    } else {
+      process.kill(pid, "SIGTERM");
+    }
+  }
+
+  async resume(sessionId: string, message: string): Promise<void> {
+    const args = [
+      "-q",
+      "--output-format",
+      "stream-json",
+      "--dangerously-set-permissions",
+      "--resume",
+      sessionId,
+      "-p",
+      message,
+    ];
+
+    const session = await this.status(sessionId).catch(() => null);
+    const cwd = session?.cwd || process.cwd();
+
+    const slatePath = await resolveBinaryPath("slate");
+    const child = spawn(slatePath, args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
+    });
+
+    child.on("error", (err) => {
+      console.error(`[slate] resume spawn error: ${err.message}`);
+    });
+
+    child.unref();
+  }
+
+  async *events(): AsyncIterable<LifecycleEvent> {
+    let knownSessions = new Map<string, AgentSession>();
+
+    const initial = await this.list({ all: true });
+    for (const s of initial) {
+      knownSessions.set(s.id, s);
+    }
+
+    try {
+      while (true) {
+        await sleep(5000);
+
+        const current = await this.list({ all: true });
+        const currentMap = new Map(current.map((s) => [s.id, s]));
+
+        for (const [id, session] of currentMap) {
+          const prev = knownSessions.get(id);
+          if (!prev) {
+            yield {
+              type: "session.started",
+              adapter: this.id,
+              sessionId: id,
+              session,
+              timestamp: new Date(),
+            };
+          } else if (
+            prev.status === "running" &&
+            session.status === "stopped"
+          ) {
+            yield {
+              type: "session.stopped",
+              adapter: this.id,
+              sessionId: id,
+              session,
+              timestamp: new Date(),
+            };
+          } else if (prev.status === "running" && session.status === "idle") {
+            yield {
+              type: "session.idle",
+              adapter: this.id,
+              sessionId: id,
+              session,
+              timestamp: new Date(),
+            };
+          }
+        }
+
+        knownSessions = currentMap;
+      }
+    } catch {
+      // iterator closed
+    }
+  }
+
+  // --- Private helpers ---
+
+  private async pollForSessionId(
+    logPath: string,
+    pid: number,
+    timeoutMs: number,
+  ): Promise<{ sessionId?: string; error?: string }> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const content = await fs.readFile(logPath, "utf-8");
+        for (const line of content.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line) as JSONLMessage;
+            if (msg.sessionId && typeof msg.sessionId === "string") {
+              return { sessionId: msg.sessionId };
+            }
+            if (msg.type === "error" || msg.error) {
+              const errMsg =
+                typeof msg.error === "string"
+                  ? msg.error
+                  : (msg.error?.message ?? JSON.stringify(msg));
+              return { error: errMsg };
+            }
+          } catch {
+            // Not valid JSON yet — might be raw stderr
+          }
+        }
+      } catch {
+        // File may not exist yet
+      }
+
+      // Check if process is still alive
+      try {
+        process.kill(pid, 0);
+      } catch {
+        // Process died — try one final read
+        return this.readLogForResult(logPath);
+      }
+
+      await sleep(200);
+    }
+    return {};
+  }
+
+  private async readLogForResult(
+    logPath: string,
+  ): Promise<{ sessionId?: string; error?: string }> {
+    try {
+      const content = await fs.readFile(logPath, "utf-8");
+      for (const line of content.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line) as JSONLMessage;
+          if (msg.sessionId) return { sessionId: msg.sessionId };
+          if (msg.type === "error" || msg.error) {
+            const errMsg =
+              typeof msg.error === "string"
+                ? msg.error
+                : (msg.error?.message ?? JSON.stringify(msg));
+            return { error: errMsg };
+          }
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // file unreadable
+    }
+    return {};
+  }
+
+  private async getLogPathForSession(
+    sessionId: string,
+  ): Promise<string | null> {
+    const meta = await readSessionMeta(this.sessionsMetaDir, sessionId);
+    if (meta?.logPath) {
+      try {
+        await fs.access(meta.logPath);
+        return meta.logPath;
+      } catch {
+        // log file gone
+      }
+    }
+
+    // Scan for log files near the launch time
+    if (meta?.launchedAt) {
+      try {
+        const files = await fs.readdir(this.sessionsMetaDir);
+        const launchMs = new Date(meta.launchedAt).getTime();
+        for (const file of files) {
+          if (!file.startsWith("launch-") || !file.endsWith(".log")) continue;
+          const tsStr = file.replace("launch-", "").replace(".log", "");
+          const ts = Number(tsStr);
+          if (!Number.isNaN(ts) && Math.abs(ts - launchMs) < 2000) {
+            return path.join(this.sessionsMetaDir, file);
+          }
+        }
+      } catch {
+        // dir doesn't exist
+      }
+    }
+    return null;
+  }
+
+  private async parseLogFile(logPath: string): Promise<{
+    cwd?: string;
+    model?: string;
+    prompt?: string;
+    tokens?: { in: number; out: number };
+    cost?: number;
+  }> {
+    try {
+      const content = await fs.readFile(logPath, "utf-8");
+      const lines = content.trim().split("\n");
+
+      let cwd: string | undefined;
+      let model: string | undefined;
+      let prompt: string | undefined;
+      let totalIn = 0;
+      let totalOut = 0;
+
+      for (const line of lines) {
+        try {
+          const msg = JSON.parse(line) as JSONLMessage;
+
+          if (msg.cwd) cwd = msg.cwd;
+
+          if (msg.type === "user" && msg.message?.content && !prompt) {
+            prompt = extractTextContent(msg.message.content);
+          }
+
+          if (msg.type === "assistant" && msg.message) {
+            if (msg.message.model) model = msg.message.model;
+            if (msg.message.usage) {
+              totalIn += msg.message.usage.input_tokens || 0;
+              totalOut += msg.message.usage.output_tokens || 0;
+            }
+          }
+        } catch {
+          // skip malformed lines
+        }
+      }
+
+      return {
+        cwd,
+        model,
+        prompt,
+        tokens:
+          totalIn || totalOut ? { in: totalIn, out: totalOut } : undefined,
+      };
+    } catch {
+      return {};
+    }
+  }
+
+  private isPidAlive(
+    pid: number,
+    recordedStartTime: string | undefined,
+    runningPids: Map<number, PidInfo>,
+  ): boolean {
+    if (!this.isProcessAlive(pid)) return false;
+
+    // Cross-check for PID recycling
+    if (recordedStartTime) {
+      const pidInfo = runningPids.get(pid);
+      if (pidInfo?.startTime) {
+        const currentStartMs = new Date(pidInfo.startTime).getTime();
+        const recordedStartMs = new Date(recordedStartTime).getTime();
+        if (
+          !Number.isNaN(currentStartMs) &&
+          !Number.isNaN(recordedStartMs) &&
+          Math.abs(currentStartMs - recordedStartMs) > 5000
+        ) {
+          return false; // PID recycled
+        }
+      }
+    }
+
+    return true;
+  }
+}
+
+// --- Utility functions ---
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getSlatePids(): Promise<Map<number, PidInfo>> {
+  const pids = new Map<number, PidInfo>();
+
+  try {
+    const { stdout } = await execFileAsync("ps", ["aux"]);
+
+    for (const line of stdout.split("\n")) {
+      if (line.includes("grep")) continue;
+
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 11) continue;
+      const pid = parseInt(fields[1], 10);
+      const command = fields.slice(10).join(" ");
+
+      // Match 'slate' command invocations with flags
+      if (!command.startsWith("slate -") && !command.startsWith("slate --"))
+        continue;
+      if (pid === process.pid) continue;
+
+      let cwd = "";
+      try {
+        const { stdout: lsofOut } = await execFileAsync("/usr/sbin/lsof", [
+          "-p",
+          pid.toString(),
+          "-Fn",
+        ]);
+        const lsofLines = lsofOut.split("\n");
+        for (let i = 0; i < lsofLines.length; i++) {
+          if (lsofLines[i] === "fcwd" && lsofLines[i + 1]?.startsWith("n")) {
+            cwd = lsofLines[i + 1].slice(1);
+            break;
+          }
+        }
+      } catch {
+        // lsof might fail
+      }
+
+      let startTime: string | undefined;
+      try {
+        const { stdout: lstart } = await execFileAsync("ps", [
+          "-p",
+          pid.toString(),
+          "-o",
+          "lstart=",
+        ]);
+        startTime = lstart.trim() || undefined;
+      } catch {
+        // ps might fail
+      }
+
+      pids.set(pid, { pid, cwd, args: command, startTime });
+    }
+  } catch {
+    // ps failed
+  }
+
+  return pids;
+}
+
+function extractTextContent(
+  content: string | Array<{ type: string; text?: string }>,
+): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((b) => b.type === "text" && b.text)
+      .map((b) => b.text as string)
+      .join("\n");
+  }
+  return "";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { OpenClawAdapter } from "./adapters/openclaw.js";
 import { OpenCodeAdapter } from "./adapters/opencode.js";
 import { PiAdapter } from "./adapters/pi.js";
 import { PiRustAdapter } from "./adapters/pi-rust.js";
+import { SlateAdapter } from "./adapters/slate.js";
 import { DaemonClient } from "./client/daemon-client.js";
 import type {
   AgentAdapter,
@@ -47,6 +48,7 @@ const adapters: Record<string, AgentAdapter> = {
   opencode: new OpenCodeAdapter(),
   pi: new PiAdapter(),
   "pi-rust": new PiRustAdapter(),
+  slate: new SlateAdapter(),
 };
 
 const client = new DaemonClient();


### PR DESCRIPTION
## Summary
- add a new `slate` adapter and register it in the CLI
- track Slate sessions via PID + JSONL logs and support launch, list, peek, status, stop, and resume flows
- add focused adapter tests covering launch args, lifecycle handling, event emission, and log parsing

Closes #140.

## Test Plan
- npm run lint
- npm run typecheck
- npm run build
- npm test
